### PR TITLE
quick hack to deal with issue of converting the string '0A1' to an int

### DIFF
--- a/admin/config_version.py
+++ b/admin/config_version.py
@@ -88,7 +88,7 @@ def config_version_get_current():
 
     major = int(v1)
     minor = int(v2)
-    micro = int(v3)
+    micro = int(v3.strip('A1'))    
 
     return "%03d%03d%03d" %(major, minor, micro)
 


### PR DESCRIPTION
This issue only makes itself known when running cherokee-admin with -x and otherwise causes cherokee-admin to be inaccessible with a 503 timeout error.
