### PR TITLE
Dead code

### DIFF
--- a/cherokee/fdpoll-epoll.c
+++ b/cherokee/fdpoll-epoll.c
@@ -128,10 +128,6 @@ _del (cherokee_fdpoll_epoll_t *fdp, int fd)
 {
 	struct epoll_event ev;
 
-	ev.events   = 0;
-	ev.data.u64 = 0;  /* <- I just wanna be sure there aren't */
-	ev.data.fd  = fd; /* <- 4 bytes uninitialized */
-
 	/* Check the fd limit
 	 */
 	if (unlikely (cherokee_fdpoll_is_empty (FDPOLL(fdp)))) {


### PR DESCRIPTION
This commit removes unnecessary epoll code when EPOLL_CTL_DEL is used.

When EPOLL_CTL_DEL is used, the epoll_event is ignored and so it does not neeed to be initialized. In fact, for Linux 2.6.9+, NULL can be passed in. However, before that, a struct epoll_event was needed (although it did not need to be initialized).
