### PR TITLE
Fix for Issue #39

### DIFF
--- a/cherokee/handler_streaming.c
+++ b/cherokee/handler_streaming.c
@@ -380,7 +380,7 @@ set_auto_rate (cherokee_handler_streaming_t *hdl)
 	if (likely (secs > 0)) {
 		long tmp;
 
-		tmp = (hdl->avformat->file_size / secs);
+		tmp = (avio_size(hdl->avformat) / secs);
 		if (tmp > rate) {
 			rate = tmp;
 			TRACE(ENTRIES, "New rate: %d bytes/s\n", rate);


### PR DESCRIPTION
Updates handler_streaming.c to calculate the file_size rather instead of calling the deprecated 'file_size' member of 'AVFormatContext'
