### PR TITLE
Fix for Issue #43: checks for the existence of glibtool using hash rather than testing for ...

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -29,7 +29,8 @@ test -z "$AUTOMAKE" && AUTOMAKE=automake
 test -z "$ACLOCAL" && ACLOCAL=aclocal
 test -z "$AUTOCONF" && AUTOCONF=autoconf
 test -z "$AUTOHEADER" && AUTOHEADER=autoheader
-if [ -x /usr/bin/glibtool ]; then
+
+if hash glibtool 2>&-; then
  test -z "$LIBTOOL" && LIBTOOL=glibtool
  test -z "$LIBTOOLIZE" && LIBTOOLIZE=glibtoolize
 else


### PR DESCRIPTION
...the hardcoded path /usr/bin/glibtool. This ensures that glibtool and glibtoolize that are not located in /usr/bin (e.g. /usr/local/bin) can be found as long as their root folder is contained in the $PATH environment variable. 

Apple uses their own version of libtool which is located at /usr/bin/libtool. The Gnu version of libtool (which autogen.sh is configured to look for) uses the g prefix (i.e. glibtool,glibtoolize.)  On systems that ship with the Gnu libtool version, testing for the existence of /usr/bin/glibtool will in most cases return true.  However, on Mac OS X it returns false regardless of whether you have the Gnu version of libtool installed somewhere else on the system (e.g. /usr/local/bin/glibtool as would be the case if you compiled and installed from source directly or via brew or similar OS X package management tool.) Using the hash command to determine if the glibtool command exists in any location rather than testing for the hardcoded existence of /usr/bin/glibtool is therefore the better overall cross-platform solution.
