### PR TITLE
Fixed Google Code Issue #1376

### DIFF
--- a/doc/cookbook_drupal.txt
+++ b/doc/cookbook_drupal.txt
@@ -116,7 +116,7 @@ another redirection rule.
 [options="header"]
 |================================================
 |Type     |Regular Expression |Redirection
-|Internal |^/(.*)\?(.*)$      |/index.php?q=$1&$2
+|Internal |^/(.\*)\?(.\*)$      |/index.php?q=$1&$2
 |================================================
 
 Fourth step
@@ -294,7 +294,7 @@ image::media/images/cookbook_drupal_dir_rules_7.png[Drupal Directory Rule]
 [options="header"]
 |================================================
 |Type     |Regular Expression |Redirection
-|Internal |^/(.*)\?(.*)$      |/blog/index.php?q=$1&$2
+|Internal |^/(.\*)\?(.\*)$      |/blog/index.php?q=$1&$2
 |Internal |^/(.*)$            |/blog/index.php?q=$1
 |================================================
 
@@ -439,7 +439,7 @@ vserver!60!rule!200!handler!rewrite!1!show = 0
 vserver!60!rule!200!handler!rewrite!1!substring = /index.php?q=$1&$2
 vserver!60!rule!200!match = request
 vserver!60!rule!200!match!final = 1
-vserver!60!rule!200!match!request = ^/(.*)\?(.*)$
+vserver!60!rule!200!match!request = ^/(.\*)\?(.\*)$
 vserver!60!rule!200!only_secure = 0
 
 # same for requests with no POST params
@@ -502,7 +502,7 @@ vserver!1000!rule!1030!match!right!match_any = 1
 vserver!1000!rule!1030!match!right!match_index_files = 0
 vserver!1000!rule!1030!match!right!match_only_files = 1
 vserver!1000!rule!1020!handler = redir
-vserver!1000!rule!1020!handler!rewrite!1!regex = ^/(.*)\?(.*)$
+vserver!1000!rule!1020!handler!rewrite!1!regex = ^/(.\*)\?(.\*)$
 vserver!1000!rule!1020!handler!rewrite!1!show = 0
 vserver!1000!rule!1020!handler!rewrite!1!substring = /blog/index.php?q=$1&$2
 vserver!1000!rule!1020!handler!rewrite!2!regex = ^/(.*)$
@@ -560,7 +560,7 @@ vserver!1020!rule!1020!match!match_any = 1
 vserver!1020!rule!1020!match!match_index_files = 0
 vserver!1020!rule!1020!match!match_only_files = 1
 vserver!1020!rule!1010!handler = redir
-vserver!1020!rule!1010!handler!rewrite!1!regex = ^/(.*)\?(.*)$
+vserver!1020!rule!1010!handler!rewrite!1!regex = ^/(.\*)\?(.\*)$
 vserver!1020!rule!1010!handler!rewrite!1!show = 0
 vserver!1020!rule!1010!handler!rewrite!1!substring = /index.php?q=$1&$2
 vserver!1020!rule!1010!handler!rewrite!2!regex = ^/(.*)$


### PR DESCRIPTION
Replaced "^/(._)\?(._)$" with "^/(.*)\?(.*)$" to prevent the loss of the asterisks due to the transformation into emphasis.

http://code.google.com/p/cherokee/issues/detail?id=1376
