### PR TITLE
 Changing /icons to /cherokee_icons (fix Google issue #1383)

### DIFF
--- a/admin/PageVServers.py
+++ b/admin/PageVServers.py
@@ -89,7 +89,7 @@ def Commit():
         CTK.cfg['%s!rule!1!handler'         %(next)] = 'common'
 
         CTK.cfg['%s!rule!2!match'           %(next)] = 'directory'
-        CTK.cfg['%s!rule!2!match!directory' %(next)] = '/icons'
+        CTK.cfg['%s!rule!2!match!directory' %(next)] = '/cherokee_icons'
         CTK.cfg['%s!rule!2!handler'         %(next)] = 'file'
         CTK.cfg['%s!rule!2!document_root'   %(next)] = CHEROKEE_ICONSDIR
 

--- a/admin/config_version.py
+++ b/admin/config_version.py
@@ -97,6 +97,19 @@ def upgrade_to_1_2_102 (cfg):
             rule_key = 'vserver!%s!rule!%s!match' % (v,r)
             rule_node = cfg[rule_key]
             update_rules_methods(cfg, rule_key, rule_node)
+            
+# Converts to 1.2.103
+def upgrade_to_1_2_103 (cfg):
+    # Replace the obsolete virtual path to /icons with /cherokee_icons:
+    # Search for rules where the value of key "document_root" ends with
+    # the string "share/cherokee/icons", and update the value of rule's
+    # key "match" to "/cherokee_icons".
+    for v in cfg.keys('vserver'):
+        for r in cfg.keys('vserver!%s!rule'%(v)):
+            if cfg.get_val('vserver!%s!rule!%s!document_root'%(v,r)) and \
+               cfg.get_val('vserver!%s!rule!%s!document_root'%(v,r)).endswith('share/cherokee/icons') and \
+               cfg.get_val('vserver!%s!rule!%s!match!directory'%(v,r)) == "/icons":
+                    cfg['vserver!%s!rule!%s!match!directory'%(v,r)] = '/cherokee_icons'
 
 def config_version_get_current():
     ver = configured.VERSION.split ('b')[0]
@@ -174,6 +187,10 @@ def config_version_update_cfg (cfg):
     # Update to.. 1.2.102
     if ver_config_i < 1002102:
         upgrade_to_1_2_102 (cfg)
+        
+    # Update to.. 1.2.103
+    if ver_config_i < 1002103:
+        upgrade_to_1_2_103 (cfg)
 
     cfg["config!version"] = ver_release_s
     return True

--- a/admin/plugins/dirlist.py
+++ b/admin/plugins/dirlist.py
@@ -32,7 +32,7 @@ URL_APPLY     = '/plugin/dirlist/apply'
 DEFAULT_THEME = "default"
 
 NOTE_THEME        = N_("Choose the listing theme.")
-NOTE_ICON_DIR     = N_("Web directory where the icon files are located. Default: <i>/icons</i>.")
+NOTE_ICON_DIR     = N_("Web directory where the icon files are located. Default: <i>/cherokee_icons</i>.")
 NOTE_NOTICE_FILES = N_("List of notice files to be inserted.")
 NOTE_HIDDEN_FILES = N_("List of files that should not be listed.")
 

--- a/admin/wizards/List.py
+++ b/admin/wizards/List.py
@@ -135,7 +135,7 @@ LIST = [
              'type':  TYPE_RULE},
             {'name':  'icons',
              'title': N_('Directory-listing Icons'),
-             'descr': N_('Add the /icons and /cherokee_themes directories used for directory listing.'),
+             'descr': N_('Add the /cherokee_icons and /cherokee_themes directories used for directory listing.'),
              'type':  TYPE_RULE},
             {'name':  'static',
              'title': N_('Static-file support'),

--- a/admin/wizards/icons.py
+++ b/admin/wizards/icons.py
@@ -35,15 +35,15 @@ from util import *
 from configured import *
 
 NOTE_WELCOME_H1 = N_("Welcome to the Icons Wizard")
-NOTE_WELCOME_P1 = N_("This wizard adds the /icons and /cherokee_themes directories so Cherokee can use icons when listing directories.")
-NOTE_WELCOME_ERR= N_("The /icons and /cherokee_themes directories are already configured. There is nothing left to do.")
+NOTE_WELCOME_P1 = N_("This wizard adds the /cherokee_icons and /cherokee_themes directories so Cherokee can use icons when listing directories.")
+NOTE_WELCOME_ERR= N_("The /cherokee_icons and /cherokee_themes directories are already configured. There is nothing left to do.")
 
 PREFIX    = 'tmp!wizard!icons'
 URL_APPLY = r'/wizard/vserver/icons/apply'
 
 CONFIG_ICONS = """
 %(rule_pre_2)s!match = directory
-%(rule_pre_2)s!match!directory = /icons
+%(rule_pre_2)s!match!directory = /cherokee_icons
 %(rule_pre_2)s!handler = file
 %(rule_pre_2)s!handler!iocache = 1
 %(rule_pre_2)s!document_root = %(droot_icons)s
@@ -107,7 +107,7 @@ class Welcome:
         icons, themes = False, False
         for r in rules:
             if CTK.get_val ('%s!rule!%s!match'%(vsrv_pre, r)) == 'directory' and \
-               CTK.cfg.get_val ('%s!rule!%s!match!directory'%(vsrv_pre, r)) == '/icons':
+               CTK.cfg.get_val ('%s!rule!%s!match!directory'%(vsrv_pre, r)) == '/cherokee_icons':
                 icons = True
             if CTK.cfg.get_val ('%s!rule!%s!match'%(vsrv_pre, r)) == 'directory' and \
                CTK.cfg.get_val ('%s!rule!%s!match!directory'%(vsrv_pre, r)) == '/cherokee_themes':

--- a/cherokee.conf.sample.pre
+++ b/cherokee.conf.sample.pre
@@ -38,7 +38,7 @@ vserver!1!rule!1!handler = common
 vserver!1!rule!1!handler!iocache = 1
 
 vserver!1!rule!2!match = directory
-vserver!1!rule!2!match!directory = /icons
+vserver!1!rule!2!match!directory = /cherokee_icons
 vserver!1!rule!2!handler = file
 vserver!1!rule!2!document_root = %prefix%/share/cherokee/icons
 

--- a/cherokee/handler_dirlist.c
+++ b/cherokee/handler_dirlist.c
@@ -52,7 +52,7 @@
 #include "human_strcmp.h"
 #include "match.h"
 
-#define ICON_WEB_DIR_DEFAULT "/icons"
+#define ICON_WEB_DIR_DEFAULT "/cherokee_icons"
 #define ENTRIES "handler,dirlist"
 
 

--- a/cherokee/main_worker.c
+++ b/cherokee/main_worker.c
@@ -68,7 +68,7 @@
 	"vserver!1!rule!3!handler = file\n"				\
 	"vserver!1!rule!3!document_root = " CHEROKEE_THEMEDIR "\n"	\
 	"vserver!1!rule!2!match = directory\n"				\
-	"vserver!1!rule!2!match!directory = /icons\n"			\
+	"vserver!1!rule!2!match!directory = /cherokee_icons\n"			\
 	"vserver!1!rule!2!handler = file\n"				\
 	"vserver!1!rule!2!document_root = " CHEROKEE_ICONSDIR "\n"	\
 	"vserver!1!rule!1!match = default\n"				\

--- a/configure.ac
+++ b/configure.ac
@@ -25,7 +25,7 @@ AC_PREREQ([2.60])
 dnl Version
 m4_define([cherokee_major_version], [1])
 m4_define([cherokee_minor_version], [2])
-m4_define([cherokee_micro_version], [102])
+m4_define([cherokee_micro_version], [103])
 m4_define([cherokee_version], m4_format('%s.%s.%s', cherokee_major_version, cherokee_minor_version, cherokee_micro_version))
 
 dnl Init autoconf and automake

--- a/po/admin/ca.po
+++ b/po/admin/ca.po
@@ -1779,8 +1779,8 @@ msgid "Choose the listing theme."
 msgstr "Escollir el tema per mostrar"
 
 #: cherokee-trunk/admin/plugins/dirlist.py:35
-msgid "Web directory where the icon files are located. Default: <i>/icons</i>."
-msgstr "Directori web on es troben els icones. Per defecte <i>/icons</i>."
+msgid "Web directory where the icon files are located. Default: <i>/cherokee_icons</i>."
+msgstr "Directori web on es troben els icones. Per defecte <i>/cherokee_icons</i>."
 
 #: cherokee-trunk/admin/plugins/dirlist.py:36
 msgid "List of notice files to be inserted."
@@ -3998,7 +3998,7 @@ msgstr "Directori-llistat d'Icones."
 
 #: cherokee-trunk/admin/wizards/List.py:130
 msgid ""
-"Add the /icons and /cherokee_themes directories used for directory listing."
+"Add the /cherokee_icons and /cherokee_themes directories used for directory listing."
 msgstr ""
 
 #: cherokee-trunk/admin/wizards/List.py:133
@@ -4129,13 +4129,13 @@ msgstr "Benvinguts al assisten de Icones"
 
 #: cherokee-trunk/admin/wizards/icons.py:38
 msgid ""
-"This wizard adds the /icons and /cherokee_themes directories so Cherokee can "
+"This wizard adds the /cherokee_icons and /cherokee_themes directories so Cherokee can "
 "use icons when listing directories."
 msgstr ""
 
 #: cherokee-trunk/admin/wizards/icons.py:39
 msgid ""
-"The /icons and /cherokee_themes directories are already configured. There is "
+"The /cherokee_icons and /cherokee_themes directories are already configured. There is "
 "nothing left to do."
 msgstr ""
 

--- a/po/admin/de.po
+++ b/po/admin/de.po
@@ -1781,7 +1781,7 @@ msgid "Choose the listing theme."
 msgstr ""
 
 #: cherokee-trunk/admin/plugins/dirlist.py:35
-msgid "Web directory where the icon files are located. Default: <i>/icons</i>."
+msgid "Web directory where the icon files are located. Default: <i>/cherokee_icons</i>."
 msgstr ""
 
 #: cherokee-trunk/admin/plugins/dirlist.py:36
@@ -4023,7 +4023,7 @@ msgstr ""
 
 #: cherokee-trunk/admin/wizards/List.py:130
 msgid ""
-"Add the /icons and /cherokee_themes directories used for directory listing."
+"Add the /cherokee_icons and /cherokee_themes directories used for directory listing."
 msgstr ""
 
 #: cherokee-trunk/admin/wizards/List.py:133
@@ -4153,13 +4153,13 @@ msgstr "Willkommen beim Icons Assistent"
 
 #: cherokee-trunk/admin/wizards/icons.py:38
 msgid ""
-"This wizard adds the /icons and /cherokee_themes directories so Cherokee can "
+"This wizard adds the /cherokee_icons and /cherokee_themes directories so Cherokee can "
 "use icons when listing directories."
 msgstr ""
 
 #: cherokee-trunk/admin/wizards/icons.py:39
 msgid ""
-"The /icons and /cherokee_themes directories are already configured. There is "
+"The /cherokee_icons and /cherokee_themes directories are already configured. There is "
 "nothing left to do."
 msgstr ""
 

--- a/po/admin/en.po
+++ b/po/admin/en.po
@@ -1823,9 +1823,9 @@ msgid "Choose the listing theme."
 msgstr "Choose the listing theme."
 
 #: cherokee-trunk/admin/plugins/dirlist.py:35
-msgid "Web directory where the icon files are located. Default: <i>/icons</i>."
+msgid "Web directory where the icon files are located. Default: <i>/cherokee_icons</i>."
 msgstr ""
-"Web directory where the icon files are located. Default: <i>/icons</i>."
+"Web directory where the icon files are located. Default: <i>/cherokee_icons</i>."
 
 #: cherokee-trunk/admin/plugins/dirlist.py:36
 msgid "List of notice files to be inserted."
@@ -4109,7 +4109,7 @@ msgstr "Allow Directory Listing"
 
 #: cherokee-trunk/admin/wizards/List.py:130
 msgid ""
-"Add the /icons and /cherokee_themes directories used for directory listing."
+"Add the /cherokee_icons and /cherokee_themes directories used for directory listing."
 msgstr ""
 
 #: cherokee-trunk/admin/wizards/List.py:133
@@ -4242,13 +4242,13 @@ msgstr "Welcome to Cherokee Admin"
 
 #: cherokee-trunk/admin/wizards/icons.py:38
 msgid ""
-"This wizard adds the /icons and /cherokee_themes directories so Cherokee can "
+"This wizard adds the /cherokee_icons and /cherokee_themes directories so Cherokee can "
 "use icons when listing directories."
 msgstr ""
 
 #: cherokee-trunk/admin/wizards/icons.py:39
 msgid ""
-"The /icons and /cherokee_themes directories are already configured. There is "
+"The /cherokee_icons and /cherokee_themes directories are already configured. There is "
 "nothing left to do."
 msgstr ""
 

--- a/po/admin/es.po
+++ b/po/admin/es.po
@@ -1779,9 +1779,9 @@ msgid "Choose the listing theme."
 msgstr "Elija el tema para mostrar."
 
 #: cherokee-trunk/admin/plugins/dirlist.py:35
-msgid "Web directory where the icon files are located. Default: <i>/icons</i>."
+msgid "Web directory where the icon files are located. Default: <i>/cherokee_icons</i>."
 msgstr ""
-"Directorio web donde se encuentran los iconos. Por defecto: <i>/icons</i>."
+"Directorio web donde se encuentran los iconos. Por defecto: <i>/cherokee_icons</i>."
 
 #: cherokee-trunk/admin/plugins/dirlist.py:36
 msgid "List of notice files to be inserted."
@@ -4049,9 +4049,9 @@ msgstr "Iconos para listado de directorios."
 
 #: cherokee-trunk/admin/wizards/List.py:130
 msgid ""
-"Add the /icons and /cherokee_themes directories used for directory listing."
+"Add the /cherokee_icons and /cherokee_themes directories used for directory listing."
 msgstr ""
-"Añadir los directorios /icons y /cherokee_themes utilizados para listar "
+"Añadir los directorios /cherokee_icons y /cherokee_themes utilizados para listar "
 "directorios."
 
 #: cherokee-trunk/admin/wizards/List.py:133
@@ -4191,18 +4191,18 @@ msgstr "Bienvenido al asistente de Iconos"
 
 #: cherokee-trunk/admin/wizards/icons.py:38
 msgid ""
-"This wizard adds the /icons and /cherokee_themes directories so Cherokee can "
+"This wizard adds the /cherokee_icons and /cherokee_themes directories so Cherokee can "
 "use icons when listing directories."
 msgstr ""
-"Este asistente añade los directorios /icons y /cherokee_themes necesarios "
+"Este asistente añade los directorios /cherokee_icons y /cherokee_themes necesarios "
 "para que Cherokee pueda utlizar iconos al hacer listados de directorios."
 
 #: cherokee-trunk/admin/wizards/icons.py:39
 msgid ""
-"The /icons and /cherokee_themes directories are already configured. There is "
+"The /cherokee_icons and /cherokee_themes directories are already configured. There is "
 "nothing left to do."
 msgstr ""
-"Los directorios /icons y /cherokee_themes ya han sido configurados. No queda "
+"Los directorios /cherokee_icons y /cherokee_themes ya han sido configurados. No queda "
 "nada por hacer. "
 
 #: cherokee-trunk/admin/wizards/alfresco.py:37

--- a/po/admin/fr.po
+++ b/po/admin/fr.po
@@ -1786,7 +1786,7 @@ msgid "Choose the listing theme."
 msgstr ""
 
 #: cherokee-trunk/admin/plugins/dirlist.py:35
-msgid "Web directory where the icon files are located. Default: <i>/icons</i>."
+msgid "Web directory where the icon files are located. Default: <i>/cherokee_icons</i>."
 msgstr ""
 
 #: cherokee-trunk/admin/plugins/dirlist.py:36
@@ -4034,7 +4034,7 @@ msgstr "Autoriser le Listage de Répertoire"
 
 #: cherokee-trunk/admin/wizards/List.py:130
 msgid ""
-"Add the /icons and /cherokee_themes directories used for directory listing."
+"Add the /cherokee_icons and /cherokee_themes directories used for directory listing."
 msgstr ""
 
 #: cherokee-trunk/admin/wizards/List.py:133
@@ -4165,13 +4165,13 @@ msgstr "Bienvenue sur Cherokee Admin"
 
 #: cherokee-trunk/admin/wizards/icons.py:38
 msgid ""
-"This wizard adds the /icons and /cherokee_themes directories so Cherokee can "
+"This wizard adds the /cherokee_icons and /cherokee_themes directories so Cherokee can "
 "use icons when listing directories."
 msgstr ""
 
 #: cherokee-trunk/admin/wizards/icons.py:39
 msgid ""
-"The /icons and /cherokee_themes directories are already configured. There is "
+"The /cherokee_icons and /cherokee_themes directories are already configured. There is "
 "nothing left to do."
 msgstr ""
 

--- a/po/admin/gl.po
+++ b/po/admin/gl.po
@@ -1768,9 +1768,9 @@ msgid "Choose the listing theme."
 msgstr "Elexir o tema do listado"
 
 #: cherokee-trunk/admin/plugins/dirlist.py:35
-msgid "Web directory where the icon files are located. Default: <i>/icons</i>."
+msgid "Web directory where the icon files are located. Default: <i>/cherokee_icons</i>."
 msgstr ""
-"Directorio onde están os ficheiros de iconas. Por omisión: <i>/icons</i>."
+"Directorio onde están os ficheiros de iconas. Por omisión: <i>/cherokee_icons</i>."
 
 #: cherokee-trunk/admin/plugins/dirlist.py:36
 msgid "List of notice files to be inserted."
@@ -4041,9 +4041,9 @@ msgstr "Listado de directorios de Iconas"
 
 #: cherokee-trunk/admin/wizards/List.py:130
 msgid ""
-"Add the /icons and /cherokee_themes directories used for directory listing."
+"Add the /cherokee_icons and /cherokee_themes directories used for directory listing."
 msgstr ""
-"Engadir os directorios /icons e /cherokee_themes usados para o listado de "
+"Engadir os directorios /cherokee_icons e /cherokee_themes usados para o listado de "
 "directorios."
 
 #: cherokee-trunk/admin/wizards/List.py:133
@@ -4187,18 +4187,18 @@ msgstr "Ben vido ó asistente Icons"
 
 #: cherokee-trunk/admin/wizards/icons.py:38
 msgid ""
-"This wizard adds the /icons and /cherokee_themes directories so Cherokee can "
+"This wizard adds the /cherokee_icons and /cherokee_themes directories so Cherokee can "
 "use icons when listing directories."
 msgstr ""
-"Este asistente engade os directorios /icons e /cherokee_themes así Cherokee "
+"Este asistente engade os directorios /cherokee_icons e /cherokee_themes así Cherokee "
 "pode usar iconas cando lista directorios."
 
 #: cherokee-trunk/admin/wizards/icons.py:39
 msgid ""
-"The /icons and /cherokee_themes directories are already configured. There is "
+"The /cherokee_icons and /cherokee_themes directories are already configured. There is "
 "nothing left to do."
 msgstr ""
-"Os directorios /icons e /cherokee_theme xa están configurados. Non queda "
+"Os directorios /cherokee_icons e /cherokee_theme xa están configurados. Non queda "
 "nada por facer."
 
 #: cherokee-trunk/admin/wizards/alfresco.py:37

--- a/po/admin/it.po
+++ b/po/admin/it.po
@@ -1780,9 +1780,9 @@ msgid "Choose the listing theme."
 msgstr "Scegli il tema."
 
 #: cherokee-trunk/admin/plugins/dirlist.py:35
-msgid "Web directory where the icon files are located. Default: <i>/icons</i>."
+msgid "Web directory where the icon files are located. Default: <i>/cherokee_icons</i>."
 msgstr ""
-"Web directory dove si trovano i file icona. Predefinito: <i>/icons </i>."
+"Web directory dove si trovano i file icona. Predefinito: <i>/cherokee_icons </i>."
 
 #: cherokee-trunk/admin/plugins/dirlist.py:36
 msgid "List of notice files to be inserted."
@@ -4062,9 +4062,9 @@ msgstr "Elenca Directory come Icone"
 
 #: cherokee-trunk/admin/wizards/List.py:130
 msgid ""
-"Add the /icons and /cherokee_themes directories used for directory listing."
+"Add the /cherokee_icons and /cherokee_themes directories used for directory listing."
 msgstr ""
-"Aggiungere le cartelle /icons e /cherokee_themes utilizzate per elencare "
+"Aggiungere le cartelle /cherokee_icons e /cherokee_themes utilizzate per elencare "
 "directory."
 
 #: cherokee-trunk/admin/wizards/List.py:133
@@ -4205,18 +4205,18 @@ msgstr "Benvenuto nella procedura guidata delle Icone"
 
 #: cherokee-trunk/admin/wizards/icons.py:38
 msgid ""
-"This wizard adds the /icons and /cherokee_themes directories so Cherokee can "
+"This wizard adds the /cherokee_icons and /cherokee_themes directories so Cherokee can "
 "use icons when listing directories."
 msgstr ""
-"Questa procedura guidata aggiunge le directory /icons e /cherokee_themes "
+"Questa procedura guidata aggiunge le directory /cherokee_icons e /cherokee_themes "
 "cosà¬ che Cherokee può utilizzare le icone quando elenca le directory."
 
 #: cherokee-trunk/admin/wizards/icons.py:39
 msgid ""
-"The /icons and /cherokee_themes directories are already configured. There is "
+"The /cherokee_icons and /cherokee_themes directories are already configured. There is "
 "nothing left to do."
 msgstr ""
-"Le directory /icons e /cherokee_themes sono già  configurate. Non è rimasto "
+"Le directory /cherokee_icons e /cherokee_themes sono già  configurate. Non è rimasto "
 "nullà altro da fare."
 
 #: cherokee-trunk/admin/wizards/alfresco.py:37

--- a/po/admin/jp.po
+++ b/po/admin/jp.po
@@ -1728,8 +1728,8 @@ msgid "Choose the listing theme."
 msgstr "一覧表示で使用するテーマ"
 
 #: cherokee-trunk/admin/plugins/dirlist.py:35
-msgid "Web directory where the icon files are located. Default: <i>/icons</i>."
-msgstr "Web上のアイコンの格納ディレクトリ。デフォルト：<i>/icons</i>"
+msgid "Web directory where the icon files are located. Default: <i>/cherokee_icons</i>."
+msgstr "Web上のアイコンの格納ディレクトリ。デフォルト：<i>/cherokee_icons</i>"
 
 #: cherokee-trunk/admin/plugins/dirlist.py:36
 msgid "List of notice files to be inserted."
@@ -3847,8 +3847,8 @@ msgstr "ディレクトリ一覧のアイコン"
 #: cherokee-trunk/admin/wizards/List.py:130
 #, fuzzy
 msgid ""
-"Add the /icons and /cherokee_themes directories used for directory listing."
-msgstr "このウィザードでは、/iconsと/cherokee_themeディレクトリに"
+"Add the /cherokee_icons and /cherokee_themes directories used for directory listing."
+msgstr "このウィザードでは、/cherokee_iconsと/cherokee_themeディレクトリに"
 
 #: cherokee-trunk/admin/wizards/List.py:133
 msgid "Static-file support"
@@ -3974,16 +3974,16 @@ msgstr "Iconsウィザードへようこそ"
 
 #: cherokee-trunk/admin/wizards/icons.py:38
 msgid ""
-"This wizard adds the /icons and /cherokee_themes directories so Cherokee can "
+"This wizard adds the /cherokee_icons and /cherokee_themes directories so Cherokee can "
 "use icons when listing directories."
-msgstr "このウィザードでは、/iconsと/cherokee_themeディレクトリに"
+msgstr "このウィザードでは、/cherokee_iconsと/cherokee_themeディレクトリに"
 
 #: cherokee-trunk/admin/wizards/icons.py:39
 #, fuzzy
 msgid ""
-"The /icons and /cherokee_themes directories are already configured. There is "
+"The /cherokee_icons and /cherokee_themes directories are already configured. There is "
 "nothing left to do."
-msgstr "このウィザードでは、/iconsと/cherokee_themeディレクトリに"
+msgstr "このウィザードでは、/cherokee_iconsと/cherokee_themeディレクトリに"
 
 #: cherokee-trunk/admin/wizards/alfresco.py:37
 msgid "Welcome to the Alfresco Wizard"

--- a/po/admin/nl.po
+++ b/po/admin/nl.po
@@ -1829,8 +1829,8 @@ msgid "Choose the listing theme."
 msgstr "Kies de lijst weergave thema."
 
 #: cherokee-trunk/admin/plugins/dirlist.py:35
-msgid "Web directory where the icon files are located. Default: <i>/icons</i>."
-msgstr "Web map waar de icoonen te vinden zijn. Standaard <i>/icons</i>."
+msgid "Web directory where the icon files are located. Default: <i>/cherokee_icons</i>."
+msgstr "Web map waar de icoonen te vinden zijn. Standaard <i>/cherokee_icons</i>."
 
 #: cherokee-trunk/admin/plugins/dirlist.py:36
 msgid "List of notice files to be inserted."
@@ -3820,8 +3820,8 @@ msgid "Directory-listing Icons"
 msgstr "Map-lijsten Iconen"
 
 #: cherokee-trunk/admin/wizards/List.py:130
-msgid "Add the /icons and /cherokee_themes directories used for directory listing."
-msgstr "Voeg de /icons en /cherokee_themes mappen toe om te tonen bij een map overzicht."
+msgid "Add the /cherokee_icons and /cherokee_themes directories used for directory listing."
+msgstr "Voeg de /cherokee_icons en /cherokee_themes mappen toe om te tonen bij een map overzicht."
 
 #: cherokee-trunk/admin/wizards/List.py:133
 msgid "Static-file support"
@@ -3928,12 +3928,12 @@ msgid "Welcome to the Icons Wizard"
 msgstr "Welkom bij de Iconen Assistent"
 
 #: cherokee-trunk/admin/wizards/icons.py:38
-msgid "This wizard adds the /icons and /cherokee_themes directories so Cherokee can use icons when listing directories."
-msgstr "Voeg de /icons en /cherokee_themes mappen toe om Cherokee iconen te laten tonen bij een map overzicht."
+msgid "This wizard adds the /cherokee_icons and /cherokee_themes directories so Cherokee can use icons when listing directories."
+msgstr "Voeg de /cherokee_icons en /cherokee_themes mappen toe om Cherokee iconen te laten tonen bij een map overzicht."
 
 #: cherokee-trunk/admin/wizards/icons.py:39
-msgid "The /icons and /cherokee_themes directories are already configured. There is nothing left to do."
-msgstr "De /icons en /cherokee_themes mappen zijn al geconfigureerd. Er is verder niets te doen."
+msgid "The /cherokee_icons and /cherokee_themes directories are already configured. There is nothing left to do."
+msgstr "De /cherokee_icons en /cherokee_themes mappen zijn al geconfigureerd. Er is verder niets te doen."
 
 #: cherokee-trunk/admin/wizards/alfresco.py:37
 msgid "Welcome to the Alfresco Wizard"
@@ -8529,8 +8529,8 @@ msgstr "OWS Fout"
 #~ msgid "Local Host Name"
 #~ msgstr "Locale Computer Naam"
 
-#~ msgid "Add the /icons directory"
-#~ msgstr "Voeg de /icons map toe"
+#~ msgid "Add the /cherokee_icons directory"
+#~ msgstr "Voeg de /cherokee_icons map toe"
 
 #~ msgid "Configure a new virtual server using Joomla."
 #~ msgstr "Configureer een nieuwe virtuele server met Joomla."

--- a/po/admin/pl.po
+++ b/po/admin/pl.po
@@ -1760,8 +1760,8 @@ msgid "Choose the listing theme."
 msgstr "Wybierz temat."
 
 #: cherokee-trunk/admin/plugins/dirlist.py:35
-msgid "Web directory where the icon files are located. Default: <i>/icons</i>."
-msgstr "Ścieżka gdzie ulokowane są pliki ikon. Domyślnie:<i>/icons</i>."
+msgid "Web directory where the icon files are located. Default: <i>/cherokee_icons</i>."
+msgstr "Ścieżka gdzie ulokowane są pliki ikon. Domyślnie:<i>/cherokee_icons</i>."
 
 #: cherokee-trunk/admin/plugins/dirlist.py:36
 msgid "List of notice files to be inserted."
@@ -3880,7 +3880,7 @@ msgstr "Ikony dla listowania"
 
 #: cherokee-trunk/admin/wizards/List.py:130
 msgid ""
-"Add the /icons and /cherokee_themes directories used for directory listing."
+"Add the /cherokee_icons and /cherokee_themes directories used for directory listing."
 msgstr ""
 
 #: cherokee-trunk/admin/wizards/List.py:133
@@ -4004,18 +4004,18 @@ msgstr "Witaj w konfiguratorze ikon"
 
 #: cherokee-trunk/admin/wizards/icons.py:38
 msgid ""
-"This wizard adds the /icons and /cherokee_themes directories so Cherokee can "
+"This wizard adds the /cherokee_icons and /cherokee_themes directories so Cherokee can "
 "use icons when listing directories."
 msgstr ""
-"Ten wizard dodaje katalogi /icons oraz /cherokee_themes po to aby Cherokee "
+"Ten wizard dodaje katalogi /cherokee_icons oraz /cherokee_themes po to aby Cherokee "
 "mógł używać ikon w momencie listowania katalogów"
 
 #: cherokee-trunk/admin/wizards/icons.py:39
 msgid ""
-"The /icons and /cherokee_themes directories are already configured. There is "
+"The /cherokee_icons and /cherokee_themes directories are already configured. There is "
 "nothing left to do."
 msgstr ""
-"Katalogi /icons oraz /cherokee_themes są już skonfigurowane. Nie ma nic do "
+"Katalogi /cherokee_icons oraz /cherokee_themes są już skonfigurowane. Nie ma nic do "
 "roboty."
 
 #: cherokee-trunk/admin/wizards/alfresco.py:37

--- a/po/admin/pt_BR.po
+++ b/po/admin/pt_BR.po
@@ -1776,7 +1776,7 @@ msgid "Choose the listing theme."
 msgstr ""
 
 #: cherokee-trunk/admin/plugins/dirlist.py:35
-msgid "Web directory where the icon files are located. Default: <i>/icons</i>."
+msgid "Web directory where the icon files are located. Default: <i>/cherokee_icons</i>."
 msgstr ""
 
 #: cherokee-trunk/admin/plugins/dirlist.py:36
@@ -4003,7 +4003,7 @@ msgstr "Permitir Listagem de diretório"
 
 #: cherokee-trunk/admin/wizards/List.py:130
 msgid ""
-"Add the /icons and /cherokee_themes directories used for directory listing."
+"Add the /cherokee_icons and /cherokee_themes directories used for directory listing."
 msgstr ""
 
 #: cherokee-trunk/admin/wizards/List.py:133
@@ -4133,13 +4133,13 @@ msgstr ""
 
 #: cherokee-trunk/admin/wizards/icons.py:38
 msgid ""
-"This wizard adds the /icons and /cherokee_themes directories so Cherokee can "
+"This wizard adds the /cherokee_icons and /cherokee_themes directories so Cherokee can "
 "use icons when listing directories."
 msgstr ""
 
 #: cherokee-trunk/admin/wizards/icons.py:39
 msgid ""
-"The /icons and /cherokee_themes directories are already configured. There is "
+"The /cherokee_icons and /cherokee_themes directories are already configured. There is "
 "nothing left to do."
 msgstr ""
 
@@ -8226,7 +8226,7 @@ msgstr "Erro"
 #~ msgstr "Escolha.."
 
 #, fuzzy
-#~ msgid "Add the /icons directory"
+#~ msgid "Add the /cherokee_icons directory"
 #~ msgstr "Caminho não é de um diretório"
 
 #, fuzzy

--- a/po/admin/sv_SE.po
+++ b/po/admin/sv_SE.po
@@ -1823,8 +1823,8 @@ msgid "Choose the listing theme."
 msgstr "Välj tema för listor."
 
 #: cherokee-trunk/admin/plugins/dirlist.py:35
-msgid "Web directory where the icon files are located. Default: <i>/icons</i>."
-msgstr "Webkatalog där ikonerna finns.  Förvalt värde: <i>/icons</i>."
+msgid "Web directory where the icon files are located. Default: <i>/cherokee_icons</i>."
+msgstr "Webkatalog där ikonerna finns.  Förvalt värde: <i>/cherokee_icons</i>."
 
 #: cherokee-trunk/admin/plugins/dirlist.py:36
 msgid "List of notice files to be inserted."
@@ -4165,9 +4165,9 @@ msgstr "Tillåt kataloglistning"
 
 #: cherokee-trunk/admin/wizards/List.py:130
 msgid ""
-"Add the /icons and /cherokee_themes directories used for directory listing."
+"Add the /cherokee_icons and /cherokee_themes directories used for directory listing."
 msgstr ""
-"Lägg till /icons och /cherokee_themes-kataloger som skall användas för visa "
+"Lägg till /cherokee_icons och /cherokee_themes-kataloger som skall användas för visa "
 "innehållet i kataloger."
 
 #: cherokee-trunk/admin/wizards/List.py:133
@@ -4307,18 +4307,18 @@ msgstr "Välkommen till Cherokee Admin"
 
 #: cherokee-trunk/admin/wizards/icons.py:38
 msgid ""
-"This wizard adds the /icons and /cherokee_themes directories so Cherokee can "
+"This wizard adds the /cherokee_icons and /cherokee_themes directories so Cherokee can "
 "use icons when listing directories."
 msgstr ""
-"Denna guiden lägger till /icons och /cherokee_theme så att Cherokee kan "
+"Denna guiden lägger till /cherokee_icons och /cherokee_theme så att Cherokee kan "
 "använda ikoner medans den visar innehållet kataloger."
 
 #: cherokee-trunk/admin/wizards/icons.py:39
 msgid ""
-"The /icons and /cherokee_themes directories are already configured. There is "
+"The /cherokee_icons and /cherokee_themes directories are already configured. There is "
 "nothing left to do."
 msgstr ""
-"/icons och /cherokee_themes-katalogerna är redan konfigurerade. Det finns "
+"/cherokee_icons och /cherokee_themes-katalogerna är redan konfigurerade. Det finns "
 "inget kvar att göra."
 
 #: cherokee-trunk/admin/wizards/alfresco.py:37
@@ -9115,7 +9115,7 @@ msgstr "Fel"
 #~ msgstr "Nytt värdnamn"
 
 #, fuzzy
-#~ msgid "Add the /icons directory"
+#~ msgid "Add the /cherokee_icons directory"
 #~ msgstr "Sökvägen är inte en katalog"
 
 #, fuzzy

--- a/po/admin/zh_CN.po
+++ b/po/admin/zh_CN.po
@@ -1758,8 +1758,8 @@ msgid "Choose the listing theme."
 msgstr "选择主题"
 
 #: cherokee-trunk/admin/plugins/dirlist.py:35
-msgid "Web directory where the icon files are located. Default: <i>/icons</i>."
-msgstr "图标文件目录,默认:<i>/icons</i>."
+msgid "Web directory where the icon files are located. Default: <i>/cherokee_icons</i>."
+msgstr "图标文件目录,默认:<i>/cherokee_icons</i>."
 
 #: cherokee-trunk/admin/plugins/dirlist.py:36
 msgid "List of notice files to be inserted."
@@ -3909,7 +3909,7 @@ msgstr ""
 
 #: cherokee-trunk/admin/wizards/List.py:130
 msgid ""
-"Add the /icons and /cherokee_themes directories used for directory listing."
+"Add the /cherokee_icons and /cherokee_themes directories used for directory listing."
 msgstr ""
 
 #: cherokee-trunk/admin/wizards/List.py:133
@@ -4037,13 +4037,13 @@ msgstr ""
 
 #: cherokee-trunk/admin/wizards/icons.py:38
 msgid ""
-"This wizard adds the /icons and /cherokee_themes directories so Cherokee can "
+"This wizard adds the /cherokee_icons and /cherokee_themes directories so Cherokee can "
 "use icons when listing directories."
 msgstr ""
 
 #: cherokee-trunk/admin/wizards/icons.py:39
 msgid ""
-"The /icons and /cherokee_themes directories are already configured. There is "
+"The /cherokee_icons and /cherokee_themes directories are already configured. There is "
 "nothing left to do."
 msgstr ""
 


### PR DESCRIPTION
Changing `/icons` to `/cherokee_icons` (fix Google issue #1383)
Incrementing version number to 1.2.103.
Adjusted `upgrade_config.py` and `config_version.py` to modify existing configurations to the new standard.
Adjusted the localisation files.
