### PR TITLE
Update obsolete automake call

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -114,7 +114,7 @@ rm -f aclocal.m4
 $ACLOCAL $ACLOCAL_FLAGS
 
 # Autoheader
-if grep "^AM_CONFIG_HEADER" configure.in >/dev/null; then
+if grep "^AC_CONFIG_HEADERS" configure.in >/dev/null; then
   echo "Running: autoheader..."
   $AUTOHEADER
 fi

--- a/configure.in
+++ b/configure.in
@@ -212,7 +212,7 @@ dnl Set the Version
 AM_INIT_AUTOMAKE(cherokee, $VERSION)
 AM_MAINTAINER_MODE
 
-AM_CONFIG_HEADER(config.h)
+AC_CONFIG_HEADERS(config.h)
 AC_SUBST(VERSION)
 
 dnl Initialize Libtool


### PR DESCRIPTION
- Fixes #56

Tested on automake 1.12.1 (openSUSE) and automake 1.13.1 (ArchLinux)
