### PR TITLE
Last of the python fixes

### DIFF
--- a/cherokee/Makefile.am
+++ b/cherokee/Makefile.am
@@ -71,10 +71,10 @@ errors.h \
 errors_defs.h
 
 errors.h: errors.py error_list.py
-	python errors.py --errors $@
+	$(PYTHON) errors.py --errors $@
 
 errors_defs.h: errors.py error_list.py
-	python errors.py --defines $@
+	$(PYTHON) errors.py --defines $@
 
 
 #


### PR DESCRIPTION
Sorry for missing this one.  Cherokee now builds without a python binary on the system.
