### PR TITLE
There is no python2 symlink on Mac OSX. generate_POTFILESin.py works wit...

### DIFF
--- a/po/admin/generate_POTFILESin.py
+++ b/po/admin/generate_POTFILESin.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 # Cherokee POTFILES.in generator
 #


### PR DESCRIPTION
...h Python 3.x so there's no reason why referencing 'python' should present a problem
