### PR TITLE
Fixed to work with Linux kernel 3.x.

### DIFF
--- a/admin/SystemStats.py
+++ b/admin/SystemStats.py
@@ -39,7 +39,7 @@ def get_system_stats():
     global _stats
 
     if not _stats:
-        if sys.platform == 'linux2':
+        if sys.platform.startswith('linux'):
             _stats = System_stats__Linux()
         elif sys.platform == 'darwin':
             _stats = System_stats__Darwin()

--- a/admin/util.py
+++ b/admin/util.py
@@ -341,7 +341,7 @@ def path_eval_exist (path_list):
 def os_get_document_root():
     if sys.platform == 'darwin':
         return "/Library/WebServer/Documents"
-    elif sys.platform == 'linux2':
+    elif sys.platform.startswith('linux'):
         if os.path.exists ("/etc/redhat-release"):
             return '/var/www'
         elif os.path.exists ("/etc/fedora-release"):

--- a/admin/wizards/php.py
+++ b/admin/wizards/php.py
@@ -607,7 +607,7 @@ def get_installation_GID():
         first_group = str(root_group)
 
     # Systems
-    if sys.platform == 'linux2':
+    if sys.platform.startswith('linux'):
         if os.getuid() == 0:
             return root_group
         return first_group


### PR DESCRIPTION
os.platform returns 'linux3' if you build your python with linux kernel 3.x.
Since Python 3.3, it returns 'linux' so it should be used with startswith('linux').

cf. http://docs.python.org/dev/library/sys.html#sys.platform
