### PR TITLE
Add Remote Debugging

### DIFF
--- a/admin/server.py
+++ b/admin/server.py
@@ -24,6 +24,11 @@
 # 02110-1301, USA.
 #
 
+# Remote Debugging
+# Uncomment the following two lines to enable remote debugging
+#import pydevd
+#pydevd.settrace('localhost', port=9091, stdoutToServer=True, stderrToServer=True)
+
 # System
 import os
 import sys


### PR DESCRIPTION
Adding lines for remote debugging. Must be enabled by uncommenting two lines.
