### PR TITLE
ssl: Allow to specify a fixed length

### DIFF
--- a/admin/PageVServer.py
+++ b/admin/PageVServer.py
@@ -48,6 +48,7 @@ NOTE_CA_LIST          = N_('File containing the trusted CA certificates, utilize
 NOTE_CIPHERS          = N_('Ciphers that TLS/SSL is allowed to use. <a target="_blank" href="http://www.openssl.org/docs/apps/ciphers.html">Reference</a>. (Default: HIGH:!aNULL:!MD5).')
 NOTE_CIPHER_SERVER_PREFERENCE = N_('The cipher sequence that is specified by the server should have preference over the preference of the client. (Default: False).')
 NOTE_COMPRESSION      = N_('Explicitly enable or disable serverside compression support. (Default: Disabled).')
+NOTE_DH_LENGTH        = N_('Explicitely sets the Diffie-Hellman parameters length. (Default: Let openssl choose).')
 NOTE_CLIENT_CERTS     = N_('Skip, Accept or Require client certificates.')
 NOTE_VERIFY_DEPTH     = N_('Limit up to which depth certificates in a chain are used during the verification procedure (Default: 1)')
 NOTE_ERROR_HANDLER    = N_('Allows the selection of how to generate the error responses.')
@@ -666,6 +667,7 @@ class SecutiryWidgetContent (CTK.Container):
         table.Add (_('Server Preference'),     CTK.CheckCfgText ('%s!ssl_cipher_server_preference' % (pre), False, _('Prefer')), _(NOTE_CIPHER_SERVER_PREFERENCE))
         table.Add (_('Client Certs. Request'), CTK.ComboCfg('%s!ssl_client_certs' %(pre), trans_options(CLIENT_CERTS)), _(NOTE_CLIENT_CERTS))
         table.Add (_('Compression'),           CTK.CheckCfgText ('%s!ssl_compression' % (pre), False, _('Prefer')), _(NOTE_COMPRESSION))
+        table.Add (_('DH length'),             CTK.ComboCfg('%s!ssl_dh_length' %(pre), [('','Auto'), ('512', '512 bits'), ('1024', '1024 bits'), ('2048', '2048 bits'), ('4096', '4096 bits')]), _(NOTE_DH_LENGTH))
 
         if CTK.cfg.get_val('%s!ssl_client_certs' %(pre)):
             table.Add (_('CA List'), CTK.TextCfg ('%s!ssl_ca_list_file' %(pre), False), _(NOTE_CA_LIST))

--- a/cherokee/cryptor_libssl.c
+++ b/cherokee/cryptor_libssl.c
@@ -374,9 +374,20 @@ _vserver_new (cherokee_cryptor_t          *cryp,
 		goto error;
 	}
 
-	/* Callback to be used when a DH parameters are required
+	/* Setup DH parameters
 	 */
-	SSL_CTX_set_tmp_dh_callback (n->context, tmp_dh_cb);
+	switch (vsrv->ssl_dh_length)
+	{
+	case 512:
+	case 1024:
+	case 2048:
+	case 4096:
+		SSL_CTX_set_tmp_dh (n->context, tmp_dh_cb(NULL, 0, vsrv->ssl_dh_length));
+		break;
+
+	default:
+		SSL_CTX_set_tmp_dh_callback (n->context, tmp_dh_cb);
+	}
 
 	/* Set ecliptic curve key parameters
 	 */

--- a/cherokee/virtual_server.c
+++ b/cherokee/virtual_server.c
@@ -71,6 +71,7 @@ cherokee_virtual_server_new (cherokee_virtual_server_t **vserver, void *server)
 
 	n->cipher_server_preference = false;
 	n->ssl_compression = false; /* This might prevent a SSL CRIME attack */
+	n->ssl_dh_length   = 0;
 
 	/* Virtual entries
 	 */
@@ -1159,6 +1160,11 @@ configure_virtual_server_property (cherokee_config_node_t *conf, void *data)
 
 	} else if (equal_buf_str (&conf->key, "ssl_compression")) {
 		ret = cherokee_atob (conf->val.buf, &vserver->ssl_compression);
+		if (ret != ret_ok)
+			return ret;
+
+	} else if (equal_buf_str (&conf->key, "ssl_dh_length")) {
+		ret = cherokee_atoi (conf->val.buf, &vserver->ssl_dh_length);
 		if (ret != ret_ok)
 			return ret;
 

--- a/cherokee/virtual_server.h
+++ b/cherokee/virtual_server.h
@@ -77,6 +77,7 @@ typedef struct {
 	cherokee_buffer_t            ciphers;
 	cherokee_boolean_t           cipher_server_preference;
 	cherokee_boolean_t           ssl_compression;
+	cuint_t                      ssl_dh_length;
 	cherokee_cryptor_vserver_t  *cryptor;
 
 	struct {


### PR DESCRIPTION
By default openssl will only get 512 or 1024 (depending only of the
"export" setting). But 1024 is a bit short nowadays and 2048 is
recommended. It does break compatibility in very rare case, so it's
left by default to auto. (there is no negotiation, the client has to
support whatever the server sends)

Signed-off-by: Sylvain Munaut tnt@246tNt.com
