### PR TITLE
ssl: Add a 'tolerate' option for client certificate verification

### DIFF
--- a/admin/PageVServer.py
+++ b/admin/PageVServer.py
@@ -48,7 +48,7 @@ NOTE_CA_LIST          = N_('File containing the trusted CA certificates, utilize
 NOTE_CIPHERS          = N_('Ciphers that TLS/SSL is allowed to use. <a target="_blank" href="http://www.openssl.org/docs/apps/ciphers.html">Reference</a>. (Default: HIGH:!aNULL:!MD5).')
 NOTE_CIPHER_SERVER_PREFERENCE = N_('The cipher sequence that is specified by the server should have preference over the preference of the client. (Default: False).')
 NOTE_COMPRESSION      = N_('Explicitly enable or disable serverside compression support. (Default: Disabled).')
-NOTE_CLIENT_CERTS     = N_('Skip, Accept or Require client certificates.')
+NOTE_CLIENT_CERTS     = N_('Skip, Tolerate, Accept or Require client certificates.')
 NOTE_VERIFY_DEPTH     = N_('Limit up to which depth certificates in a chain are used during the verification procedure (Default: 1)')
 NOTE_ERROR_HANDLER    = N_('Allows the selection of how to generate the error responses.')
 NOTE_PERSONAL_WEB     = N_('Directory inside the user home directory to use as root web directory. Disabled if empty.')

--- a/admin/consts.py
+++ b/admin/consts.py
@@ -224,6 +224,7 @@ EVHOSTS = [
 
 CLIENT_CERTS = [
     ('',         N_('Skip')),
+    ('tolerate', N_('Tolerate')),
     ('accept',   N_('Accept')),
     ('required', N_('Require'))
 ]

--- a/cherokee/cryptor_libssl.c
+++ b/cherokee/cryptor_libssl.c
@@ -337,6 +337,12 @@ tmp_dh_cb (SSL *ssl, int export, int keylen)
 	return NULL;
 }
 
+static int
+verify_tolerate_cb(int preverify_ok, X509_STORE_CTX *x509_store)
+{
+	return 1;
+}
+
 
 static ret_t
 _vserver_new (cherokee_cryptor_t          *cryp,
@@ -517,7 +523,10 @@ _vserver_new (cherokee_cryptor_t          *cryp,
 		}
 	}
 
-	SSL_CTX_set_verify (n->context, verify_mode, NULL);
+	if (cherokee_buffer_cmp_str (&vsrv->req_client_certs, "tolerate") == 0)
+		SSL_CTX_set_verify (n->context, verify_mode, verify_tolerate_cb);
+	else
+		SSL_CTX_set_verify (n->context, verify_mode, NULL);
 	SSL_CTX_set_verify_depth (n->context, vsrv->verify_depth);
 
 	SSL_CTX_set_read_ahead (n->context, 1);


### PR DESCRIPTION
This option is very similar to accept with the exception that if the
certificate that's sent by the client can't be validated, the SSL
handshake will not be abruptly terminate but it will continue.

The application that use the client certificate should in any case call
the SSL_get_verify_status and this will still return that the validation
failed and the cert be ignored.

This is mainly useful because Apple, in it's great wisdom, decided to
make Safari send just about any client cert, even those not matching at
all the CA list sent by the server ... The only way to use client cert
with Safari is then to just accept any client cert and just ignore it
if it's invalid rather than preventing the SSL negotiation.

Signed-off-by: Sylvain Munaut tnt@246tNt.com
