### PR TITLE
Fix #880

### DIFF
--- a/admin/PageEntry.py
+++ b/admin/PageEntry.py
@@ -107,6 +107,12 @@ def Clone():
     next = CTK.cfg.get_next_entry_prefix ('vserver!%s!rule'%(vsrv))
 
     CTK.cfg.clone ('vserver!%s!rule!%s'%(vsrv,rule), next)
+    
+    if CTK.cfg.get_val ("%s!match"%(next)) == "default":
+        # TODO: ideally create an any match, opposed to regular expression
+        CTK.cfg["%s!match"%(next)] = 'request'
+        CTK.cfg["%s!match!request"%(next)] = '/.*'
+
     return CTK.cfg_reply_ajax_ok()
 
 


### PR DESCRIPTION
It is a good thing Cherokee allows to clone rules. Currently
cloning the default rule, creates a duplicate where the match
section cannot be changed. Obviously this is not expected.
This improvement fakes a default behavior by the request match
with regular expression /.*

Ideally we might need an any match, which helps with a global
configuration option implemented by a non-final, any match.
Think of the use case of protecting the entire virtual server
with a password.
