### PR TITLE
The server starts normally if TLS wasn't selected but a port was defined.

### DIFF
--- a/cherokee/server.c
+++ b/cherokee/server.c
@@ -740,7 +740,7 @@ vservers_check_tls (cherokee_server_t *srv)
 			if (srv->cryptor == NULL) {
 				LOG_CRITICAL (CHEROKEE_ERROR_SERVER_NO_CRYPTOR,
 					      VSERVER(i)->name.buf);
-				return ret_error;
+				return ret_not_found;
 			}
 
 			TRACE (ENTRIES, "Virtual Server %s: TLS enabled\n", VSERVER(i)->name.buf);


### PR DESCRIPTION
Lets just gracefully handle the fact that TLS wasn't selected, and solve in the admin it should have been done.
