### PR TITLE
Don't set X-Forwarded-SSL: ON when headers indicate SSL was OFF before.

### DIFF
--- a/cherokee/handler_proxy.c
+++ b/cherokee/handler_proxy.c
@@ -549,7 +549,7 @@ build_request (cherokee_handler_proxy_t *hdl,
 			char *c = begin + 16;
 			while (*c == ' ') c++;
 
-			XFS &= (! strncasecmp (c, "on", 7));
+			XFS &= (! strncasecmp (c, "on", 2));
 			goto next;
 		}
 		else if (! strncasecmp (begin, "X-Real-IP:", 10))


### PR DESCRIPTION
My guess is that this could be merged. The following behavior is changed:

When an incomming SSL connection has an X-Forwarded-SSL which is OFF
the X-Forwarded-SSL will never set to ON. The only way that X-Forwarded-SSL
can be ON:
- there is a secure connection and no X-Forwarded-SSL header is present -> ON
- there is a secure connection and X-Forwarded-SSL is ON -> ON

In all other cases X-Forwarded SSL will be set OFF:
- there is no secure connection and no header X-Forward-SSL -> OFF
- there is no secure connection and X-Forwarded-SSL is ON -> OFF

There is a potential optimisation to copy the existing off header.
For readibility I did not go in that direction.

Fix #1073
