### PR TITLE
Remove check for sizeof(sig_atomic_t).

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -266,7 +266,6 @@ AC_CHECK_SIZEOF(unsigned long long)
 AC_CHECK_SIZEOF(unsigned int)
 AC_CHECK_SIZEOF(off_t)
 AC_CHECK_SIZEOF(size_t)
-AC_CHECK_SIZEOF(sig_atomic_t)
 AC_CHECK_SIZEOF(time_t)
 
 AC_CACHE_CHECK([for long long],samba_cv_have_longlong,[


### PR DESCRIPTION
It was introduced in 42c26023 with no commit message. The check was not
working in the first place (signal.h was not being included in the test
program) and there's no code using the resulting value.
