### PR TITLE
SHA{1,512}: Rename structs and functions

### DIFF
--- a/cherokee/buffer.c
+++ b/cherokee/buffer.c
@@ -1801,13 +1801,13 @@ cherokee_buffer_encode_md5 (cherokee_buffer_t *buf, cherokee_buffer_t *encoded)
 ret_t
 cherokee_buffer_encode_sha1 (cherokee_buffer_t *buf, cherokee_buffer_t *encoded)
 {
-	SHA_INFO sha1;
+	CHEROKEE_SHA_INFO sha1;
 
-	sha_init (&sha1);
-	sha_update (&sha1, (unsigned char*) buf->buf, buf->len);
+	cherokee_sha_init (&sha1);
+	cherokee_sha_update (&sha1, (unsigned char*) buf->buf, buf->len);
 
 	cherokee_buffer_ensure_size (encoded, SHA1_DIGEST_SIZE + 1);
-	sha_final (&sha1, (unsigned char *) encoded->buf);
+	cherokee_sha_final (&sha1, (unsigned char *) encoded->buf);
 
 	encoded->len = SHA1_DIGEST_SIZE;
 	encoded->buf[encoded->len] = '\0';
@@ -1821,11 +1821,11 @@ cherokee_buffer_encode_sha1_digest (cherokee_buffer_t *buf)
 {
 	int           i;
 	unsigned char digest[SHA1_DIGEST_SIZE];
-	SHA_INFO      sha1;
+	CHEROKEE_SHA_INFO      sha1;
 
-	sha_init (&sha1);
-	sha_update (&sha1, (unsigned char*) buf->buf, buf->len);
-	sha_final (&sha1, digest);
+	cherokee_sha_init (&sha1);
+	cherokee_sha_update (&sha1, (unsigned char*) buf->buf, buf->len);
+	cherokee_sha_final (&sha1, digest);
 
 	cherokee_buffer_ensure_size (buf, (2 * SHA1_DIGEST_SIZE)+1);
 
@@ -1874,13 +1874,13 @@ cherokee_buffer_encode_sha1_base64 (cherokee_buffer_t *buf, cherokee_buffer_t *e
 ret_t
 cherokee_buffer_encode_sha512 (cherokee_buffer_t *buf, cherokee_buffer_t *encoded)
 {
-	SHA512_CTX sha512;
+	CHEROKEE_SHA512_CTX sha512;
 
-	SHA512_Init (&sha512);
-	SHA512_Update (&sha512, (unsigned char*) buf->buf, buf->len);
+	cherokee_SHA512_Init (&sha512);
+	cherokee_SHA512_Update (&sha512, (unsigned char*) buf->buf, buf->len);
 
 	cherokee_buffer_ensure_size (encoded, SHA512_DIGEST_LENGTH + 1);
-	SHA512_Final (&sha512, (unsigned char *) encoded->buf);
+	cherokee_SHA512_Final (&sha512, (unsigned char *) encoded->buf);
 
 	encoded->len = SHA512_DIGEST_LENGTH;
 	encoded->buf[encoded->len] = '\0';
@@ -1894,11 +1894,11 @@ cherokee_buffer_encode_sha512_digest (cherokee_buffer_t *buf)
 {
 	int           i;
 	unsigned char digest[SHA512_DIGEST_LENGTH];
-	SHA512_CTX    sha512;
+	CHEROKEE_SHA512_CTX    sha512;
 
-	SHA512_Init   (&sha512);
-	SHA512_Update (&sha512, (unsigned char*) buf->buf, buf->len);
-	SHA512_Final  (&sha512, digest);
+	cherokee_SHA512_Init   (&sha512);
+	cherokee_SHA512_Update (&sha512, (unsigned char*) buf->buf, buf->len);
+	cherokee_SHA512_Final  (&sha512, digest);
 
 	cherokee_buffer_ensure_size (buf, (2 * SHA512_DIGEST_LENGTH)+1);
 

--- a/cherokee/sha1.c
+++ b/cherokee/sha1.c
@@ -71,7 +71,7 @@ typedef unsigned long ULONG;
 
 
 static void
-sha_transform (SHA_INFO *sha_info)
+sha_transform (CHEROKEE_SHA_INFO *sha_info)
 {
 	int i;
 	U8 *dp;
@@ -189,7 +189,7 @@ nether regions of the anatomy...
 
 /* initialize the SHA digest */
 
-void sha_init(SHA_INFO *sha_info)
+void cherokee_sha_init(CHEROKEE_SHA_INFO *sha_info)
 {
 	sha_info->digest[0] = 0x67452301L;
 	sha_info->digest[1] = 0xefcdab89L;
@@ -204,7 +204,7 @@ void sha_init(SHA_INFO *sha_info)
 /* update the SHA digest */
 
 void
-sha_update (SHA_INFO *sha_info, U8 *buffer, int count)
+cherokee_sha_update (CHEROKEE_SHA_INFO *sha_info, U8 *buffer, int count)
 {
 	int i;
 	ULONG clo;
@@ -241,7 +241,7 @@ sha_update (SHA_INFO *sha_info, U8 *buffer, int count)
 }
 
 
-static void sha_transform_and_copy(unsigned char digest[20], SHA_INFO *sha_info)
+static void sha_transform_and_copy(unsigned char digest[20], CHEROKEE_SHA_INFO *sha_info)
 {
 	sha_transform(sha_info);
 	digest[ 0] = (unsigned char) ((sha_info->digest[0] >> 24) & 0xff);
@@ -268,7 +268,7 @@ static void sha_transform_and_copy(unsigned char digest[20], SHA_INFO *sha_info)
 
 /* finish computing the SHA digest */
 void
-sha_final (SHA_INFO *sha_info, unsigned char digest[20])
+cherokee_sha_final (CHEROKEE_SHA_INFO *sha_info, unsigned char digest[20])
 {
 	int count;
 	ULONG lo_bit_count, hi_bit_count;

--- a/cherokee/sha1.h
+++ b/cherokee/sha1.h
@@ -12,11 +12,11 @@ typedef struct {
 	unsigned long count_lo, count_hi;  /* 64-bit bit count */
 	unsigned char data[SHA_BLOCKSIZE]; /* SHA data buffer */
 	int local;                         /* unprocessed amount in data */
-} SHA_INFO;
+} CHEROKEE_SHA_INFO;
 
 
-void sha_init   (SHA_INFO *sha_info);
-void sha_update (SHA_INFO *sha_info, unsigned char *buffer, int count);
-void sha_final  (SHA_INFO *sha_info, unsigned char digest[20]);
+void cherokee_sha_init   (CHEROKEE_SHA_INFO *sha_info);
+void cherokee_sha_update (CHEROKEE_SHA_INFO *sha_info, unsigned char *buffer, int count);
+void cherokee_sha_final  (CHEROKEE_SHA_INFO *sha_info, unsigned char digest[20]);
 
 #endif /* CHEROKEE_SHA1 */

--- a/cherokee/sha512.c
+++ b/cherokee/sha512.c
@@ -98,7 +98,7 @@ static const uint64_t constant_512[80] = {
 };
 
 void
-SHA512_Init (SHA512_CTX *m)
+cherokee_SHA512_Init (CHEROKEE_SHA512_CTX *m)
 {
 	m->sz[0] = 0;
 	m->sz[1] = 0;
@@ -113,7 +113,7 @@ SHA512_Init (SHA512_CTX *m)
 }
 
 static void
-calc (SHA512_CTX *m, uint64_t *in)
+calc (CHEROKEE_SHA512_CTX *m, uint64_t *in)
 {
 	uint64_t AA, BB, CC, DD, EE, FF, GG, HH;
 	uint64_t data[80];
@@ -191,7 +191,7 @@ struct x64{
 #endif
 
 void
-SHA512_Update (SHA512_CTX *m, const void *v, size_t len)
+cherokee_SHA512_Update (CHEROKEE_SHA512_CTX *m, const void *v, size_t len)
 {
 	const unsigned char *p = v;
 	size_t old_sz = m->sz[0];
@@ -228,7 +228,7 @@ SHA512_Update (SHA512_CTX *m, const void *v, size_t len)
 }
 
 void
-SHA512_Final (SHA512_CTX *m, void *res)
+cherokee_SHA512_Final (CHEROKEE_SHA512_CTX *m, void *res)
 {
 	unsigned char zeros[128 + 16];
 	unsigned offset = (m->sz[0] / 8) % 128;
@@ -253,7 +253,7 @@ SHA512_Final (SHA512_CTX *m, void *res)
 	zeros[dstart+2] = (m->sz[1] >> 40) & 0xff;
 	zeros[dstart+1] = (m->sz[1] >> 48) & 0xff;
 	zeros[dstart+0] = (m->sz[1] >> 56) & 0xff;
-	SHA512_Update (m, zeros, dstart + 16);
+	cherokee_SHA512_Update (m, zeros, dstart + 16);
 	{
 		int i;
 		unsigned char *r = (unsigned char*)res;

--- a/cherokee/sha512.h
+++ b/cherokee/sha512.h
@@ -13,10 +13,10 @@ struct hc_sha512state {
 	unsigned char save[128];
 };
 
-typedef struct hc_sha512state SHA512_CTX;
+typedef struct hc_sha512state CHEROKEE_SHA512_CTX;
 
-void SHA512_Init   (SHA512_CTX *);
-void SHA512_Update (SHA512_CTX *, const void *, size_t);
-void SHA512_Final  (SHA512_CTX *, void *);
+void cherokee_SHA512_Init   (CHEROKEE_SHA512_CTX *);
+void cherokee_SHA512_Update (CHEROKEE_SHA512_CTX *, const void *, size_t);
+void cherokee_SHA512_Final  (CHEROKEE_SHA512_CTX *, void *);
 
 #endif /* CHEROKEE_SHA512 */


### PR DESCRIPTION
```
By ensuring that the SHA1 and SHA512 code in Cherokee does
not stomp on symbols provided by libssl, we prevent a problem
where the relative sizes of the structs means that Cherokee's
SHA512 operations break SSL handshakes.
```

Signed-Off-By: Daniel Silverstone dsilvers@digital-scurf.org
