### PR TITLE
Make the SSL tests run

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1103,6 +1103,8 @@ if test "$WITH_OPENSSL" != "no"; then
 	   AC_SUBST(LIBSSL_CFLAGS)
 
 	   AC_DEFINE(HAVE_OPENSSL, 1, [Have OpenSSL library])
+	   AC_PATH_PROG([OPENSSL_BIN], [openssl])
+	   AC_SUBST(OPENSSL_BIN)
     fi
 fi
 AC_MSG_CHECKING(for libssl)

--- a/qa/Makefile.am
+++ b/qa/Makefile.am
@@ -327,6 +327,22 @@ run-tests.py \
 304-Dirlist-TransferEncoding.py \
 305-Error-ContentLength.py
 
-test:
+if USE_OPENSSL
+ssl-keys/set-1.pem: ssl-keys/set-1.key openssl.cnf
+	@OPENSSL_BIN@ req -batch -config openssl.cnf -new -x509 -key ssl-keys/set-1.key -out ssl-keys/set-1.pem -days 1095
+ssl-keys/set-1.key:
+	mkdir -p ssl-keys
+	@OPENSSL_BIN@ genrsa -out ssl-keys/set-1.key 2048
+test-ssl: ssl-keys/set-1.pem
+	./run-tests.py -s
+test: test-non-ssl test-ssl
+
+DISTCLEANFILES += ssl-keys/set-1.pem ssl-keys/set-1.key
+
+else
+test: test-non-ssl
+endif
+
+test-non-ssl:
 	python -m compileall .
 	./run-tests.py

--- a/qa/conf.py.pre
+++ b/qa/conf.py.pre
@@ -17,8 +17,8 @@ LOGGER_ACCESS     = "access.log"
 LOGGER_ERROR      = "error.log"
 
 # TLS/SSL
-SSL_CERT_FILE     = "/etc/cherokee/ssl/cherokee.crt"
-SSL_CERT_KEY_FILE = "/etc/cherokee/ssl/cherokee.key"
+SSL_CERT_FILE     = "ssl-keys/set-1.pem"
+SSL_CERT_KEY_FILE = "ssl-keys/set-1.key"
 
 # Misc options
 SERVER_DELAY      = 10

--- a/qa/openssl.cnf
+++ b/qa/openssl.cnf
@@ -1,0 +1,141 @@
+HOME				= .
+RANDFILE			= $ENV::HOME/.rnd
+openssl_conf			= openssl_init
+
+[ openssl_init ]
+oid_section			= new_oids
+engines				= engine_section
+
+[ new_oids ]
+
+[ ca ]
+default_ca			= CA_default		# The default ca section
+
+[ CA_default ]
+
+dir				= .			# Where everything is kept
+certs				= $dir			# Where the issued certs are kept
+crl_dir				= $dir			# Where the issued crl are kept
+database			= $dir/index.txt	# database index file.
+new_certs_dir			= $dir			# default place for new certs.
+
+certificate			= $dir/ca.crt		# The CA certificate
+serial				= $dir/serial		# The current serial number
+crl				= $dir/crl.pem		# The current CRL
+private_key			= $dir/ca.key		# The private key
+RANDFILE			= $dir/.rand		# private random number file
+
+x509_extensions			= usr_cert		# The extentions to add to the cert
+
+default_days			= 3650			# how long to certify for
+default_crl_days		= 30			# how long before next CRL
+default_md			= sha1			# which md to use.
+preserve			= no			# keep passed DN ordering
+
+policy				= policy_anything
+
+[ policy_match ]
+countryName			= match
+stateOrProvinceName		= match
+organizationName		= match
+organizationalUnitName		= optional
+commonName			= supplied
+name				= optional
+emailAddress			= optional
+
+[ policy_anything ]
+countryName			= optional
+stateOrProvinceName		= optional
+localityName			= optional
+organizationName		= optional
+organizationalUnitName		= optional
+commonName			= supplied
+name				= optional
+emailAddress			= optional
+
+[ req ]
+default_bits			= 2048
+default_keyfile			= privkey.pem
+distinguished_name		= req_distinguished_name
+attributes			= req_attributes
+x509_extensions			= v3_ca			# The extentions to add to the self signed cert
+
+string_mask = nombstr
+
+[ req_distinguished_name ]
+countryName			= Country Name (2 letter code)
+countryName_default		= XX
+countryName_min			= 2
+countryName_max			= 2
+
+stateOrProvinceName		= State or Province Name (full name)
+stateOrProvinceName_default	= Snake Oil Land
+
+localityName			= Locality Name (eg, city)
+localityName_default		= Snake Oil Town
+
+0.organizationName		= Organization Name (eg, company)
+0.organizationName_default	= Cherokee Snake Oil Peddlars
+
+organizationalUnitName		= Organizational Unit Name (eg, section)
+organizationalUnitName_default  = Cherokee Snake Oil Smearing Team
+
+commonName			= Common Name (eg, your name or your server\'s hostname)
+commonName_max			= 64
+commonName_default              = localhost
+
+name				= Name
+name_max			= 64
+name_default                    =
+
+emailAddress			= Email Address
+emailAddress_default		= snakeoil@cherokee-webserver.com
+emailAddress_max		= 40
+
+[ req_attributes ]
+challengePassword		= A challenge password
+challengePassword_min		= 4
+challengePassword_max		= 20
+
+unstructuredName		= An optional company name
+
+[ usr_cert ]
+
+basicConstraints=CA:FALSE
+nsComment			= "Cherokee Snake Oil Test Certificate"
+
+subjectKeyIdentifier		= hash
+authorityKeyIdentifier		= keyid,issuer:always
+extendedKeyUsage		= clientAuth
+keyUsage			= digitalSignature
+
+[ server ]
+
+basicConstraints=CA:FALSE
+nsCertType			= server
+nsComment			= "Cherokee Snake Oil Test Server Certificate"
+subjectKeyIdentifier		= hash
+authorityKeyIdentifier		= keyid,issuer:always
+extendedKeyUsage		= serverAuth
+keyUsage			= digitalSignature, keyEncipherment
+
+[ v3_req ]
+
+basicConstraints		= CA:FALSE
+keyUsage			= nonRepudiation, digitalSignature, keyEncipherment
+
+[ v3_ca ]
+
+subjectKeyIdentifier		= hash
+
+authorityKeyIdentifier		= keyid:always,issuer:always
+
+basicConstraints		= CA:true
+
+[ crl_ext ]
+
+authorityKeyIdentifier		= keyid:always,issuer:always
+
+[ engine_section ]
+
+

--- a/qa/run-tests.py
+++ b/qa/run-tests.py
@@ -216,6 +216,7 @@ CONF_BASE = """
 server!bind!1!port = %(PORT)d
 server!bind!1!interface = %(listen)s
 server!bind!2!port = %(PORT_TLS)d
+server!bind!2!interface = %(listen)s
 server!bind!2!tls = 1
 server!keepalive = 1
 server!panic_action = %(panic)s
@@ -257,8 +258,9 @@ if method:
     CONF_BASE += "server!poll_method = %s" % (method)
 
 if ssl:
-    CONF_BASE += """
+    CONF_BASE = """
 server!tls = libssl
+""" + CONF_BASE + """
 vserver!1!ssl_certificate_file = %(SSL_CERT_FILE)s
 vserver!1!ssl_certificate_key_file = %(SSL_CERT_KEY_FILE)s
 """ % (globals())


### PR DESCRIPTION
This patch adds an SSL key set for use during tests and causes the SSL tests to
be run if the server was built with OPENSSL support.  In addition we fix the
TLS port to be bound to 127.0.0.1 which fixes 073's behaviour in SSL mode on an
IPv6 enabled host.

Signed-Off-By: Daniel Silverstone dsilvers@digital-scurf.org
