### PR TITLE
Add a note about the "libtool-bin" package for Debian systems

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,10 @@ either by default or by running the following on Debian-based systems::
 
     sudo apt-get install autoconf automake libtool
 
-or, for Yum-based systems, such as RedHat, CentOS or Fedora::
+You also may need to install the ``libtool-bin`` package, depending on the
+distribution and architecture.
+
+For Yum-based systems, such as RedHat, CentOS or Fedora::
 
     sudo yum install autoconf automake libtool
 


### PR DESCRIPTION
Certain Debian systems make `/usr/bin/libtool` is present in the `libtool-bin` package, whereas, on others, it is present in the `libtool` package.

https://packages.debian.org/search?searchon=contents&keywords=%2Fusr%2Fbin%2Flibtool&mode=path&suite=stable&arch=any

This PR adds a note to README.rst regarding this.