### PR TITLE
Fix SIGTERM handling in cherokee main process

### DIFF
--- a/cherokee/handler_cgi.c
+++ b/cherokee/handler_cgi.c
@@ -215,7 +215,7 @@ cherokee_handler_cgi_free (cherokee_handler_cgi_t *cgi)
 		while (true) {
 			do {
 				pid = waitpid (cgi->pid, NULL, WNOHANG);
-			} while ((pid == 1) && (errno == EINTR));
+			} while ((pid == -1) && (errno == EINTR));
 
 			if (pid > 0) {
 				/* Ok */

--- a/cherokee/main.c
+++ b/cherokee/main.c
@@ -705,6 +705,7 @@ main (int argc, char *argv[])
 	if (ret != ret_ok)
 		exit (EXIT_ERROR);
 
+	setpgid(0, 0);
 	set_signals();
 	single_time = is_single_execution (argc, argv);
 


### PR DESCRIPTION
If cherokee is not run in daemon mode, it will send a SIGTERM to its process group when receiving a SIGTERM. This might kill the parent process as well. To prevent this, setpgid() is used to create a new process group for cherokee and its child processes. fixes #1189