### PR TITLE
Use relative paths in the handler_server_info page

### DIFF
--- a/cherokee/handler_server_info.c
+++ b/cherokee/handler_server_info.c
@@ -52,7 +52,7 @@
 "       text-align: center; background-color: #cfd9e8; }"                                           CRLF\
 "a { color: #2d5e9a; }"                                                                             CRLF\
 "a:hover { color: #164987; }"                                                                       CRLF\
-"#container { background: #fff url({request}/logo.gif) 32px 16px no-repeat; "                       CRLF\
+"#container { background: #fff url(logo.gif) 32px 16px no-repeat; "                                 CRLF\
 "              border: 1px solid #bacce2; width: 640px; min-width: 640px; "                         CRLF\
 "              margin: 32px auto; text-align: left; }"                                              CRLF\
 "#container-inner { padding: 32px 32px 32px 128px; }"                                               CRLF\
@@ -75,10 +75,10 @@
 "<div id=\"information\"></div>"                                                                    CRLF\
 "<div id=\"otherways\">"                                                                            CRLF\
 "<p>The same information can also be fetched properly encoded to be consumed from: "                CRLF\
-"<a href=\"{request}/info/py\">Python</a>, "                                                        CRLF\
-"<a href=\"{request}/info/ruby\">Ruby</a>, "                                                        CRLF\
-"<a href=\"{request}/info/js\">JavaScript</a> and "                                                 CRLF\
-"<a href=\"{request}/info/php\">PHP</a>.</div>"
+"<a href=\"info/py\">Python</a>, "                                                                  CRLF\
+"<a href=\"info/ruby\">Ruby</a>, "                                                                  CRLF\
+"<a href=\"info/js\">JavaScript</a> and "                                                           CRLF\
+"<a href=\"info/php\">PHP</a>.</div>"
 
 #define AJAX_JS                                                                                         \
 "<script type=\"text/javascript\">"                                                                 CRLF\
@@ -178,7 +178,7 @@
 "    }"                                                                                             CRLF\
 "  }"                                                                                               CRLF\
 "}"                                                                                                 CRLF\
-"tmp = new ajaxObject ('{request}/info/js');"                                                       CRLF\
+"tmp = new ajaxObject ('info/js');"                                                                 CRLF\
 "tmp.callback = function(txt) {"                                                                    CRLF\
 "  var data = null;"                                                                                CRLF\
 "  var div = document.getElementById('information');"                                               CRLF\
@@ -619,10 +619,6 @@ server_info_build_html (cherokee_handler_server_info_t *hdl, cherokee_buffer_t *
 	cherokee_version_add (&ver, HANDLER_SRV(hdl)->server_token);
 	cherokee_buffer_replace_string (buffer, "{cherokee_name}", 15, ver.buf, ver.len);
 	cherokee_buffer_mrproper (&ver);
-
-	cherokee_buffer_replace_string (buffer, "{request}", 9,
-	                                HANDLER_CONN(hdl)->request.buf,
-	                                HANDLER_CONN(hdl)->request.len);
 
 	cherokee_buffer_add_str (buffer, PAGE_FOOT);
 	return ret_ok;

--- a/qa/307-ServerInfo.py
+++ b/qa/307-ServerInfo.py
@@ -1,0 +1,20 @@
+from base import *
+
+MAGIC = '"><script>alert(1)</script>'
+
+CONF = """
+vserver!1!rule!3070!match = directory
+vserver!1!rule!3070!match!directory = /server_info
+vserver!1!rule!3070!handler = server_info
+"""
+
+class Test (TestBase):
+    def __init__ (self):
+        TestBase.__init__ (self, __file__)
+        self.name = "Server Info, prevent XSS via URL"
+
+        self.request           = "GET /server_info/%s HTTP/1.0\r\n" % (MAGIC)
+        self.conf              = CONF
+        self.expected_error    = 200
+        self.forbidden_content = MAGIC
+

--- a/qa/Makefile.am
+++ b/qa/Makefile.am
@@ -326,7 +326,9 @@ run-tests.py \
 302-DirIndex3.py \
 304-Dirlist-TransferEncoding.py \
 305-Error-ContentLength.py \
-306-NoContent-keepalive.py
+306-NoContent-keepalive.py \
+307-ServerInfo.py \
+\
 
 if USE_OPENSSL
 ssl-keys/set-1.pem: ssl-keys/set-1.key openssl.cnf


### PR DESCRIPTION
Issue #1227 describes a XSS vulnerability on the about page of cherokee-admin.
While the report by LogicalTrust only describes a JavaScript variant, a CSS method could also be probed via logo.gif.

The root cause is the request being verbatim copied in to the HTML template. The request could be escaped, but leads to the question: Why are we presenting a full path, instead of a
relative path to the page? This change removes the full path, and makes it relative. No URL is being printed in the template, and the XSS is avoided and therefore it should also be
faster.