### PR TITLE
XSS vulnerability in handler_error via cherokee_buffer_add_escape_html

### DIFF
--- a/cherokee/buffer.c
+++ b/cherokee/buffer.c
@@ -1497,6 +1497,14 @@ cherokee_buffer_add_escape_html (cherokee_buffer_t *buf, cherokee_buffer_t *src)
 	if (src->buf[src->len] != '\0')
 		src->buf[src->len]  = '\0';
 
+	/* Verify there are no embedded '\0'.
+	 */
+	p0 = src->buf;
+	for (p1 = p0; *p1 != '\0'; ++p1);
+
+	if (unlikely ((cuint_t)(p1 - src->buf) != src->len))
+		return ret_error;
+
 	/* Verify if string has to be escaped.
 	 */
 	if ((p0 = strpbrk (src->buf, "<>&\"")) == NULL) {
@@ -1526,11 +1534,6 @@ cherokee_buffer_add_escape_html (cherokee_buffer_t *buf, cherokee_buffer_t *src)
 				continue;
 		}
 	}
-
-	/* Verify there are no embedded '\0'.
-	 */
-	if (unlikely ((cuint_t)(p1 - src->buf) != src->len))
-		return ret_error;
 
 	/* Ensure there is proper buffer size.
 	 */

--- a/qa/308-HandlerErrorXSS.py
+++ b/qa/308-HandlerErrorXSS.py
@@ -1,0 +1,15 @@
+from base import *
+
+MAGIC = '<H1>xss</H1>'
+
+class Test (TestBase):
+    def __init__ (self):
+        TestBase.__init__ (self, __file__)
+        self.name = "Handler Error XSS after \\0"
+
+        self.expected_error    = 400
+        self.request           = "GET / \r\n" +\
+                                 "Connection: Keep-alive\r\n" +\
+                                 "\r\n" +\
+                                 "few\x00xx%s" % (MAGIC) 
+        self.forbidden_content = MAGIC

--- a/qa/Makefile.am
+++ b/qa/Makefile.am
@@ -328,6 +328,7 @@ run-tests.py \
 305-Error-ContentLength.py \
 306-NoContent-keepalive.py \
 307-ServerInfo.py \
+308-HandlerErrorXSS.py \
 \
 
 if USE_OPENSSL


### PR DESCRIPTION
In Issue #1223 LogicalTrust describes an XSS in the 400 page. When providing a buffer that contains a \0 char strpbrk will not be able to find characters afterwards.
This leads to the question: should we beable to return escaped sequences containing \0 values. Since the original function assumed those should not exists this code might guard for
it. But I do wonder if it is elegant enough to do so.

A subsequent question was raised if the 400 page should return "bad input" a discussion on this feature is started in #1230