### PR TITLE
Handle multiple results from getaddrinfo in different families

### DIFF
--- a/cherokee/resolv_cache.c
+++ b/cherokee/resolv_cache.c
@@ -297,7 +297,7 @@ cherokee_resolv_cache_get_host (cherokee_resolv_cache_t *resolv,
 
 	/* Copy it to the socket object
 	 */
-	ret = cherokee_socket_update_from_addrinfo (sock, addr, 0);
+	ret = cherokee_socket_update_from_addrinfo (sock, addr);
 	if (ret != ret_ok) {
 		return ret;
 	}

--- a/cherokee/socket.c
+++ b/cherokee/socket.c
@@ -364,24 +364,10 @@ cherokee_socket_set_sockaddr (cherokee_socket_t *socket, int fd, cherokee_sockad
 
 ret_t
 cherokee_socket_update_from_addrinfo (cherokee_socket_t     *socket,
-                                      const struct addrinfo *addr,
-                                      cuint_t                num)
+                                      const struct addrinfo *addr)
 {
-	const struct addrinfo *ai;
-
 	if (unlikely (addr == NULL))
 		return ret_error;
-
-	/* Find the right address
-	 */
-	ai = addr;
-	while (num > 0) {
-		num -= 1;
-		ai   = ai->ai_next;
-		if (ai == NULL) {
-			return ret_not_found;
-		}
-	}
 
 	/* Copy the information
 	 */
@@ -390,11 +376,13 @@ cherokee_socket_update_from_addrinfo (cherokee_socket_t     *socket,
 
 	switch (addr->ai_family) {
 	case AF_INET:
-		memcpy (&SOCKET_SIN_ADDR(socket), &((struct sockaddr_in *) ai->ai_addr)->sin_addr, sizeof(struct in_addr));
+		memcpy (&SOCKET_SIN_ADDR(socket), &((struct sockaddr_in *) addr->ai_addr)->sin_addr, sizeof(struct in_addr));
 		break;
+#ifdef HAVE_IPV6
 	case AF_INET6:
-		memcpy (&SOCKET_SIN6_ADDR(socket), &((struct sockaddr_in6 *) ai->ai_addr)->sin6_addr, sizeof(struct in6_addr));
+		memcpy (&SOCKET_SIN6_ADDR(socket), &((struct sockaddr_in6 *) addr->ai_addr)->sin6_addr, sizeof(struct in6_addr));
 		break;
+#endif
 	default:
 		SHOULDNT_HAPPEN;
 		return ret_error;

--- a/cherokee/socket.h
+++ b/cherokee/socket.h
@@ -147,6 +147,6 @@ ret_t cherokee_socket_writev (cherokee_socket_t *socket, const struct iovec *vec
 /* Extra
  */
 ret_t cherokee_socket_set_sockaddr         (cherokee_socket_t *socket, int fd, cherokee_sockaddr_t *sa);
-ret_t cherokee_socket_update_from_addrinfo (cherokee_socket_t *socket, const struct addrinfo *addr_info, cuint_t num);
+ret_t cherokee_socket_update_from_addrinfo (cherokee_socket_t *socket, const struct addrinfo *addr_info);
 
 #endif /* CHEROKEE_SOCKET_H */

--- a/cherokee/source.c
+++ b/cherokee/source.c
@@ -185,7 +185,7 @@ long_path:
 			return ret_error;
 		}
 
-		ret = cherokee_socket_update_from_addrinfo (sock, src->addr_current, 0);
+		ret = cherokee_socket_update_from_addrinfo (sock, src->addr_current);
 		if (unlikely (ret != ret_ok)) {
 			return ret_error;
 		}

--- a/qa/TODO
+++ b/qa/TODO
@@ -11,3 +11,6 @@ Bug 1364 defines the following:
     Please, do not hesitate to report it at http://bugs.cherokee-project.com/
     so  the developer team can fix it.
 -----
+
+Issue #1236 defines the use of a DNS entry that results both an IPv4 and an IPv6 address.
+Test if the selection of the proxy is using all addresses, in all protocols.


### PR DESCRIPTION
This commit changes something fundamental in the proxy handling. Previously the proxy was iterating over multiple possible IP addresses received from the source definition. The issue #1226 shows that this fails when mixing IPv4 and IPv6 results. This could be resolved by just taking the "right" addrinfo result, but this is executed after the socket has been created, hence: if we would have an IPv6 result, but created an IPv4 socket, we would miss all checks that happen upon socket creation.

The iteration over the getaddrinfo results has now been pulled into the proxy specific code, this might still be able to be abstracted.