### PR TITLE
Enhance the log messages for authentication failures

### DIFF
--- a/cherokee/connection.c
+++ b/cherokee/connection.c
@@ -2310,6 +2310,7 @@ cherokee_connection_check_authentication (cherokee_connection_t *conn, cherokee_
 	 */
 	ret = cherokee_header_get_known (&conn->header, header_authorization, &ptr, &len);
 	if (ret != ret_ok) {
+		LOG_ERROR_S(CHEROKEE_ERROR_CONNECTION_HEADER_AUTH);
 		goto unauthorized;
 	}
 
@@ -2325,6 +2326,7 @@ cherokee_connection_check_authentication (cherokee_connection_t *conn, cherokee_
 	 */
 	ret = get_authorization (conn, config_entry->authentication, conn->validator, ptr, len);
 	if (ret != ret_ok) {
+		LOG_ERROR_S(CHEROKEE_ERROR_CONNECTION_AUTH_GET_HEADER);
 		goto unauthorized;
 	}
 
@@ -2334,11 +2336,13 @@ cherokee_connection_check_authentication (cherokee_connection_t *conn, cherokee_
 		void *foo;
 
 		if (cherokee_buffer_is_empty (&conn->validator->user)) {
+			LOG_ERROR_S(CHEROKEE_ERROR_CONNECTION_NO_USER);
 			goto unauthorized;
 		}
 
 		ret = cherokee_avl_get (config_entry->users, &conn->validator->user, &foo);
 		if (ret != ret_ok) {
+			LOG_ERROR(CHEROKEE_ERROR_CONNECTION_NO_VALID_USER, conn->validator->user.buf);
 			goto unauthorized;
 		}
 	}
@@ -2354,6 +2358,7 @@ cherokee_connection_check_authentication (cherokee_connection_t *conn, cherokee_
 	ret = cherokee_validator_check (conn->validator, conn);
 
 	if (ret != ret_ok) {
+		LOG_ERROR_S(CHEROKEE_ERROR_CONNECTION_LOGIN_ERROR);
 		goto unauthorized;
 	}
 

--- a/cherokee/error_list.py
+++ b/cherokee/error_list.py
@@ -964,6 +964,27 @@ e('THREAD_CREATE',
 
 # cherokee/connection.c
 #
+
+e('CONNECTION_HEADER_AUTH',
+  title = "Could not get authentication information from the header",
+  desc  = CODING_BUG)
+
+e('CONNECTION_AUTH_GET_HEADER',
+  title = "Could not parse the authentication information in the header",
+  desc  = "The authentication information in the connection header does not match with the configuration type.")
+
+e('CONNECTION_LOGIN_ERROR',
+  title = "Login failed: invalid password",
+  desc  = "The supplied password is invalid.")
+
+e('CONNECTION_NO_USER',
+  title = "The connection does not have users",
+  desc  = BROKEN_CONFIG)
+
+e('CONNECTION_NO_VALID_USER',
+  title = "The connection's user (%s) is not valid, please check the configuration.",
+  desc  = BROKEN_CONFIG)
+
 e('CONNECTION_AUTH',
   title = "Unknown authentication method",
   desc  = BROKEN_CONFIG)


### PR DESCRIPTION
I hope you are safe and well in this difficult times.

In the `cherokee_connection_check_authentication()` function, Cherokee will check the authorization info in the connection during the setup stage. When the authentication fails, there is little info about how it failed. (e.g. wrong authentication type, invalid user, or wrong password.) All the messages are simply 401 unauthorized errors.

I feel it would be beneficial to create some more hints for the sysadmins to know how the authentication fails when users were denied access. So I created some messages inside the authorization function,  before it returns an unauthorized error.

Any thoughts are appreciated! 
