### PR TITLE
Enhance the log messages for authentication failures in TRACE

### DIFF
--- a/cherokee/connection.c
+++ b/cherokee/connection.c
@@ -2310,6 +2310,7 @@ cherokee_connection_check_authentication (cherokee_connection_t *conn, cherokee_
 	 */
 	ret = cherokee_header_get_known (&conn->header, header_authorization, &ptr, &len);
 	if (ret != ret_ok) {
+		TRACE(ENTRIES, "conn %p, no authorization header entry\n", conn);
 		goto unauthorized;
 	}
 
@@ -2325,6 +2326,7 @@ cherokee_connection_check_authentication (cherokee_connection_t *conn, cherokee_
 	 */
 	ret = get_authorization (conn, config_entry->authentication, conn->validator, ptr, len);
 	if (ret != ret_ok) {
+		TRACE(ENTRIES, "conn %p, authentication information does not match with configuration.\n", conn);
 		goto unauthorized;
 	}
 
@@ -2334,11 +2336,13 @@ cherokee_connection_check_authentication (cherokee_connection_t *conn, cherokee_
 		void *foo;
 
 		if (cherokee_buffer_is_empty (&conn->validator->user)) {
+			TRACE(ENTRIES, "conn %p, user field is empty.\n", conn);
 			goto unauthorized;
 		}
 
 		ret = cherokee_avl_get (config_entry->users, &conn->validator->user, &foo);
 		if (ret != ret_ok) {
+			TRACE(ENTRIES, "conn %p, the connection's user (%s) is not in the fixed list configuration.\n", conn, conn->validator->user.buf);
 			goto unauthorized;
 		}
 	}
@@ -2354,6 +2358,7 @@ cherokee_connection_check_authentication (cherokee_connection_t *conn, cherokee_
 	ret = cherokee_validator_check (conn->validator, conn);
 
 	if (ret != ret_ok) {
+		TRACE(ENTRIES, "conn %p, login failed: invalid password.\n", conn);
 		goto unauthorized;
 	}
 
@@ -2386,6 +2391,8 @@ cherokee_connection_check_ip_validation (cherokee_connection_t *conn, cherokee_c
 	}
 
 	conn->error_code = http_access_denied;
+	TRACE(ENTRIES, "conn %p, IP did not match IP or subnet configuration.\n", conn);
+
 	return ret_error;
 }
 
@@ -2430,6 +2437,7 @@ cherokee_connection_check_http_method (cherokee_connection_t *conn, cherokee_con
 		conn->header.method = http_get;
 	}
 
+	TRACE(ENTRIES, "conn %p, the connecction's HTTP method is not allowed.\n", conn);
 	return ret_error;
 }
 

--- a/cherokee/error_list.py
+++ b/cherokee/error_list.py
@@ -58,7 +58,7 @@ e('RRD_DIR_PERMS',
   admin = '/general#tabs_general-0')
 
 e('RRD_MKDIR_WRITE',
-  title = "Cannot create the '%s' directory",
+  title = "Cannot create the '%s' directory or it doesn't have write permission",
   desc  = SYSTEM_ISSUE,
   admin = '/general#tabs_general-0')
 


### PR DESCRIPTION
Add several log messages in TRACE() level for the authentication failures in order to show some hints when users were denied access.

I also changed the log message for `cherokee_mkdir_p_perm` a bit to make it more accurate.