### PR TITLE
Update log messages in reading config files

### DIFF
--- a/cherokee/config_reader.c
+++ b/cherokee/config_reader.c
@@ -75,7 +75,10 @@ do_include (cherokee_config_node_t *conf, cherokee_buffer_t *path)
 		int               entry_len;
 
 		dir = cherokee_opendir (path->buf);
-		if (dir == NULL) return ret_error;
+		if (dir == NULL) {
+			LOG_CRITICAL (CHEROKEE_ERROR_CONF_OPEN_DIR, path->buf);
+			return ret_error;
+		}
 
 		while ((entry = readdir(dir)) != NULL) {
 			ret_t             ret;

--- a/cherokee/error_list.py
+++ b/cherokee/error_list.py
@@ -765,7 +765,12 @@ e('SRC_INTER_CHROOT',
 #
 e('CONF_READ_ACCESS_FILE',
   title   = "Could not access file",
-  desc    = "The configuration file '%s' could not be accessed. Most probably the server user does not have enough permissions to read it.",
+  desc    = "The configuration file '%s' could not be accessed. Most probably the server user does not have enough permissions to read it, or lacks search permission on the file path.",
+  show_bt = False)
+
+e('CONF_OPEN_DIR',
+  title   = "Could not open directory",
+  desc    = "Could not open directory '%s'. Please check the server user and file permissions.",
   show_bt = False)
 
 e('CONF_READ_CHILDREN_SAME_NODE',


### PR DESCRIPTION
I changed the log messages in the function `do_include` a bit which is used for reading config files.

- First, `cherokee_stat ` may fail because of lacking [search permissions](https://pubs.opengroup.org/onlinepubs/009695399/functions/stat.html) on the config file path. It's better to tell the detailed potential reason, so they will not simply look at the file itself which may have correct permissions
- Second, the failure of `cherokee_opendir` is not logged, so I create another log to log this error. 

Any feedback is appreciated. Thanks!