### PR TITLE
Add error message when authentication fails

### DIFF
--- a/cherokee/connection.c
+++ b/cherokee/connection.c
@@ -2330,6 +2330,7 @@ cherokee_connection_check_authentication (cherokee_connection_t *conn, cherokee_
 	 */
 	ret = get_authorization (conn, config_entry->authentication, conn->validator, ptr, len);
 	if (ret != ret_ok) {
+		LOG_ERROR_S(CHEROKEE_ERROR_CONNECTION_AUTH_GET_HEADER);
 		goto unauthorized;
 	}
 
@@ -2359,6 +2360,7 @@ cherokee_connection_check_authentication (cherokee_connection_t *conn, cherokee_
 	ret = cherokee_validator_check (conn->validator, conn);
 
 	if (ret != ret_ok) {
+		LOG_ERROR_S(CHEROKEE_ERROR_CONNECTION_AUTH_CHECK);
 		goto unauthorized;
 	}
 

--- a/cherokee/error_list.py
+++ b/cherokee/error_list.py
@@ -981,6 +981,14 @@ e('CONNECTION_GET_VSERVER',
   title = "Could not get virtual server: '%s'",
   desc  = CODING_BUG)
 
+e('CONNECTION_AUTH_CHECK',
+  title = "Login failed in authentication",
+  desc  = "Wrong username or password.")
+
+e('CONNECTION_AUTH_GET_HEADER',
+  title = "Authentication failed: could not parse the authentication config",
+  desc  = BROKEN_CONFIG)
+
 
 # cherokee/ncpus.c
 #


### PR DESCRIPTION
Kindly leave a hint when the authentication fails, like wrong user-password pair or wrong config format.