### PR TITLE
Update log message for cherokee_mkdir_p_perm

### DIFF
--- a/cherokee/error_list.py
+++ b/cherokee/error_list.py
@@ -58,7 +58,7 @@ e('RRD_DIR_PERMS',
   admin = '/general#tabs_general-0')
 
 e('RRD_MKDIR_WRITE',
-  title = "Cannot create the '%s' directory",
+  title = "Cannot create the '%s' directory; or the directory doesn't have write permission",
   desc  = SYSTEM_ISSUE,
   admin = '/general#tabs_general-0')
 

--- a/cherokee/error_list.py
+++ b/cherokee/error_list.py
@@ -58,7 +58,7 @@ e('RRD_DIR_PERMS',
   admin = '/general#tabs_general-0')
 
 e('RRD_MKDIR_WRITE',
-  title = "Cannot create the '%s' directory; or the directory doesn't have write permission",
+  title = "Cannot create the '%s' directory; or the directory doesn't have write permissions",
   desc  = SYSTEM_ISSUE,
   admin = '/general#tabs_general-0')
 


### PR DESCRIPTION
`cherokee_mkdir_p_perm` may fail for two reasons, one is could not create the directory, one is the existing directory does not have write permission. Update the log message to better reflect the cause.