### PR TITLE
Add log message when open file directory fails

### DIFF
--- a/cherokee/error_list.py
+++ b/cherokee/error_list.py
@@ -255,6 +255,11 @@ e('HANDLER_ERROR_REDIR_URL',
   title = "HTTP Error %d redirection: An 'url' property is required",
   desc  = BROKEN_CONFIG)
 
+# cherokee/handler_error_nn.c
+#
+e('HANDLER_ERROR_OPEN_DIR',
+  title   = "Could not open directory",
+  desc    = "Could not open directory '%s'. Please check the server user and file permissions.")
 
 # cherokee/handler_dirlist.c
 #

--- a/cherokee/handler_error_nn.c
+++ b/cherokee/handler_error_nn.c
@@ -73,8 +73,10 @@ get_nearest_from_directory (char *directory, char *request, cherokee_buffer_t *o
 	cherokee_boolean_t found    = false;
 
 	dir = cherokee_opendir (directory);
-	if (dir == NULL)
+	if (dir == NULL) {
+		LOG_CRITICAL (CHEROKEE_ERROR_HANDLER_ERROR_OPEN_DIR, directory);
 		goto go_out;
+	}
 
 	for (;;) {
 		re = cherokee_readdir (dir, (struct dirent *)entry_buf, &entry);


### PR DESCRIPTION
Leave a log message when `cherokee_opendir` fails in the `error_nn` handler.