### PR TITLE
Add a log message when the user is not found

### DIFF
--- a/cherokee/connection.c
+++ b/cherokee/connection.c
@@ -2032,6 +2032,7 @@ cherokee_connection_build_local_directory_userdir (cherokee_connection_t     *co
 	 */
 	ret = cherokee_getpwnam (conn->userdir.buf, &pwd, tmp, sizeof(tmp));
 	if ((ret != ret_ok) || (pwd.pw_dir == NULL)) {
+		LOG_ERROR (CHEROKEE_ERROR_CONNECTION_NO_USER, conn->userdir.buf);
 		conn->error_code = http_not_found;
 		return ret_error;
 	}

--- a/cherokee/error_list.py
+++ b/cherokee/error_list.py
@@ -981,6 +981,9 @@ e('CONNECTION_GET_VSERVER',
   title = "Could not get virtual server: '%s'",
   desc  = CODING_BUG)
 
+e('CONNECTION_NO_USER',
+  title = "User '%s' not found in the system",
+  desc  = "The server is trying to build the local directory string. However, it seems that the user does not exist in the system.")
 
 # cherokee/ncpus.c
 #


### PR DESCRIPTION
Currently, the server directly returns user-not-found when it could not find the correct user. I add a log message to leave a hint before returns 404.