### PR TITLE
Add a log message when open local directory fails

### DIFF
--- a/cherokee/error_list.py
+++ b/cherokee/error_list.py
@@ -221,6 +221,10 @@ e('HANDLER_SRV_INFO_TYPE',
 e('HANDLER_FILE_TIME_PARSE',
   title = "Unparseable time '%s'")
 
+e('HANDLER_FILE_OPEN',
+  title = "Could not open directory ",
+  desc  = "Could not open directory '%s'. Please check the server user and file permissions.")
+
 
 # cherokee/handler_ssi.c
 #

--- a/cherokee/handler_file.c
+++ b/cherokee/handler_file.c
@@ -344,6 +344,7 @@ open_local_directory (cherokee_handler_file_t *fhdl, cherokee_buffer_t *local_fi
 	 */
 	switch (errno) {
 	case EACCES:
+		LOG_WARNING (CHEROKEE_ERROR_HANDLER_FILE_OPEN, local_file->buf);
 		conn->error_code = http_access_denied;
 		break;
 	case ENOENT:


### PR DESCRIPTION
Before return access denied, kindly leave a message to lead admins to file permissions