### PR TITLE
create the mutex before creating threads

### DIFF
--- a/cherokee/collector_rrd.c
+++ b/cherokee/collector_rrd.c
@@ -376,13 +376,11 @@ cherokee_collector_rrd_new (cherokee_collector_rrd_t **rrd,
 		LOG_ERROR (CHEROKEE_ERROR_COLLECTOR_NEW_MUTEX, re);
 		return ret_error;
 	}
-	
 	re = pthread_create (&n->thread, NULL, rrd_thread_worker_func, n);
 	if (re != 0) {
 		LOG_ERROR (CHEROKEE_ERROR_COLLECTOR_NEW_THREAD, re);
 		return ret_error;
 	}
-	
 	/* Return obj
 	 */
 	*rrd = n;

--- a/cherokee/collector_rrd.c
+++ b/cherokee/collector_rrd.c
@@ -370,18 +370,19 @@ cherokee_collector_rrd_new (cherokee_collector_rrd_t **rrd,
 	 */
 	n->exiting = false;
 
-	re = pthread_create (&n->thread, NULL, rrd_thread_worker_func, n);
-	if (re != 0) {
-		LOG_ERROR (CHEROKEE_ERROR_COLLECTOR_NEW_THREAD, re);
-		return ret_error;
-	}
-
+		
 	re = pthread_mutex_init (&n->mutex, NULL);
 	if (re != 0) {
 		LOG_ERROR (CHEROKEE_ERROR_COLLECTOR_NEW_MUTEX, re);
 		return ret_error;
 	}
-
+	
+	re = pthread_create (&n->thread, NULL, rrd_thread_worker_func, n);
+	if (re != 0) {
+		LOG_ERROR (CHEROKEE_ERROR_COLLECTOR_NEW_THREAD, re);
+		return ret_error;
+	}
+	
 	/* Return obj
 	 */
 	*rrd = n;


### PR DESCRIPTION
Hi, I create a PR to adjust the order of creating mutexes and threads. If the created thread `n->thread` uses the mutex, it would be a potential bug. My suggestion is to make the code more reliable by slightly adjusting the code.